### PR TITLE
Install node_modules into their own directory in the docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM node:current
 
-COPY .neutrinorc.js package.json webpack.config.js /app/
+COPY .neutrinorc.js package.json webpack.config.js yarn.lock /app/
 COPY src/ /app/src/
 
 WORKDIR /app

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,12 @@ services:
       - PORT=9000
     volumes:
       - .:/app
+      - node_modules:/app/node_modules
     entrypoint:
-      - /usr/local/bin/yarn
-      - start
+      - /bin/bash
+      - --login
+      - -c
+      - yarn install && yarn start
+
+volumes:
+  node_modules:


### PR DESCRIPTION
… to avoid root owned file issues.

This avoids having a shared `node_modules` between the host and container, which often causes issues with file ownership or other conflicts.