### PR TITLE
Remove console error

### DIFF
--- a/src/components/RuleCard/index.jsx
+++ b/src/components/RuleCard/index.jsx
@@ -315,7 +315,7 @@ function RuleCard({ rule, ...props }) {
                 <ListItem className={classes.listItem}>
                   <ListItemText
                     primary="64-bit Migration Opt-in"
-                    secondary={rule.mig64}
+                    secondary={String(rule.mig64)}
                   />
                 </ListItem>
               )}
@@ -323,7 +323,7 @@ function RuleCard({ rule, ...props }) {
                 <ListItem className={classes.listItem}>
                   <ListItemText
                     primary="Incompatible JAWS Screen Reader"
-                    secondary={rule.jaws}
+                    secondary={String(rule.jaws)}
                   />
                 </ListItem>
               )}


### PR DESCRIPTION
Fixes https://github.com/mozilla-frontend-infra/balrog-ui/issues/26.

Reason: the secondary prop expects a string but we were feeding it a boolean.