### PR TITLE
Add Roboto font

### DIFF
--- a/.neutrinorc.js
+++ b/.neutrinorc.js
@@ -20,7 +20,8 @@ module.exports = {
         },
         html: {
           title: 'Balrog Admin',
-          favicon: `${__dirname}/src/images/favicon.png`
+          favicon: `${__dirname}/src/images/favicon.png`,
+          template: 'src/index.html',
         },
         env: {
           HOST: DEFAULT_HOST,

--- a/src/index.html
+++ b/src/index.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8"/>
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700&display=swap" />
+</head>
+<body>
+    <div id="root"></div>
+</body>
+</html>


### PR DESCRIPTION
Resolves #52.

From https://material-ui.com/getting-started/installation/#roboto-font:

> Material-UI was designed with the Roboto font in mind

This uses `display=swap` that was recently introduced to make sure we don't block the initial paint by displaying a fallback font while the font is being retrieved.

https://font-display.glitch.me/