### PR TITLE
Only show incomplete scheduled changes on Rules view.

### DIFF
--- a/src/services/rules.js
+++ b/src/services/rules.js
@@ -14,7 +14,7 @@ const deleteRule = ({ ruleId, dataVersion }) =>
 // const addRule = () => axios.post();
 // const revertRule = () => axios.post();
 const getScheduledChanges = all => {
-  if (!all || all === true) {
+  if (all === true) {
     return axios.get(`/scheduled_changes/rules?${stringify({ all: 1 })}`);
   }
 


### PR DESCRIPTION
I've changed the default behaviour for the service because it's very rare we want to see completed scheduled changes.