### PR TITLE
Add multi text selection in AutoCompleteText

### DIFF
--- a/src/components/AutoCompleteText/ChipList.jsx
+++ b/src/components/AutoCompleteText/ChipList.jsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import classNames from 'classnames';
+import { object, func, arrayOf, string } from 'prop-types';
+import { makeStyles } from '@material-ui/styles';
+import Chip from '@material-ui/core/Chip';
+import CloseIcon from 'mdi-react/CloseIcon';
+
+const useStyles = makeStyles(theme => ({
+  container: {
+    display: 'flex',
+  },
+  chip: {
+    marginRight: theme.spacing(1),
+    fontSize: theme.typography.caption.fontSize,
+  },
+}));
+
+function ChipList(props) {
+  const { selectedItems, className, onItemDelete, chipProps, ...rest } = props;
+  const classes = useStyles();
+
+  return (
+    <div className={classNames(classes.container, className)} {...rest}>
+      {selectedItems.map(item => (
+        <Chip
+          key={item}
+          className={classes.chip}
+          size="small"
+          deleteIcon={<CloseIcon />}
+          label={item}
+          onDelete={() => onItemDelete(item)}
+          onClick={() => onItemDelete(item)}
+          {...chipProps}
+        />
+      ))}
+    </div>
+  );
+}
+
+ChipList.propTypes = {
+  selectedItems: arrayOf(string).isRequired,
+  onItemDelete: func.isRequired,
+  chipProps: object,
+};
+
+ChipList.defaultProps = {
+  chipProps: null,
+};
+
+export default ChipList;

--- a/src/components/AutoCompleteText/index.jsx
+++ b/src/components/AutoCompleteText/index.jsx
@@ -1,11 +1,13 @@
 import React from 'react';
-import { string, bool, object, func } from 'prop-types';
+import { arrayOf, string, bool, object, func } from 'prop-types';
 import classNames from 'classnames';
 import Downshift from 'downshift';
+import { equals } from 'ramda';
 import { makeStyles } from '@material-ui/styles';
 import TextField from '@material-ui/core/TextField';
 import MenuItem from '@material-ui/core/MenuItem';
 import Paper from '@material-ui/core/Paper';
+import ChipList from './ChipList';
 
 const useStyles = makeStyles(theme => ({
   paper: {
@@ -34,12 +36,42 @@ function AutoCompleteText({
   required,
   getSuggestions,
   inputProps,
+  selectedItems,
+  onSelectedItemsChange,
+  multi,
   ...props
 }) {
   const classes = useStyles();
+  const handleChipDelete = item => {
+    const chips = selectedItems.filter(selectedItem => selectedItem !== item);
+
+    if (onSelectedItemsChange) {
+      onSelectedItemsChange(chips);
+    }
+  };
+
+  const handleChipAdd = item => {
+    const chips = new Set([...selectedItems, item]);
+    const updatedChips = Array.from(chips);
+
+    // Avoid duplicate chips
+    if (!equals(updatedChips, selectedItems)) {
+      if (onSelectedItemsChange) {
+        onSelectedItemsChange(updatedChips);
+      }
+    }
+
+    // Clear input value to give space for more selections
+    onValueChange('');
+  };
+
   const handleStateChange = changes => {
     if ('selectedItem' in changes) {
       onValueChange(changes.selectedItem);
+
+      if (multi) {
+        handleChipAdd(changes.selectedItem);
+      }
     } else if ('inputValue' in changes) {
       onValueChange(changes.inputValue);
     }
@@ -81,12 +113,36 @@ function AutoCompleteText({
         isOpen,
         selectedItem,
       }) => (
-        <div>
+        <div className={classNames({ [classes.multiWrapper]: multi })}>
           <TextField
             label={label}
             required={required}
             fullWidth
-            InputProps={getInputProps(inputProps)}
+            InputProps={{
+              ...getInputProps({
+                onKeyDown(event) {
+                  if (event.key === 'Backspace' && !inputValue) {
+                    handleChipDelete(selectedItems[selectedItems.length - 1]);
+                  }
+
+                  if (event.key === 'Enter') {
+                    event.preventDefault();
+
+                    if (multi && selectedItem && highlightedIndex === null) {
+                      handleChipAdd(selectedItem);
+                    }
+                  }
+                },
+              }),
+              startAdornment: multi ? (
+                <ChipList
+                  selectedItems={selectedItems}
+                  onItemDelete={handleChipDelete}
+                />
+              ) : (
+                undefined
+              ),
+            }}
           />
           {getSuggestions && (
             <div className={classes.paperWrapper} {...getMenuProps()}>
@@ -112,19 +168,29 @@ function AutoCompleteText({
 }
 
 AutoCompleteText.propTypes = {
+  // Callback triggered when the value of the text field is changed.
   onValueChange: func.isRequired,
   value: string.isRequired,
   getSuggestions: func,
   inputProps: object,
   label: string,
   required: bool,
+  // Selected items for when `multi` is set to `true`.
+  selectedItems: arrayOf(string),
+  // Callback triggered when the list of chips change.
+  onSelectedItemsChange: func,
+  // If true, the text field will allow multi text selection
+  multi: bool,
 };
 
 AutoCompleteText.defaultProps = {
   getSuggestions: null,
+  selectedItems: [],
+  onSelectedItemsChange: null,
   inputProps: {},
   label: '',
   required: false,
+  multi: false,
 };
 
 export default AutoCompleteText;


### PR DESCRIPTION
Fixes https://github.com/mozilla-frontend-infra/balrog-ui/issues/56.

In order to test this, you can do:

```diff
diff --git a/src/views/RequiredSignoffs/ViewSignoff/index.jsx b/src/views/RequiredSignoffs/ViewSignoff/index.jsx
index 09f69d6..20ea284 100644
--- a/src/views/RequiredSignoffs/ViewSignoff/index.jsx
+++ b/src/views/RequiredSignoffs/ViewSignoff/index.jsx
@@ -77,6 +77,7 @@ function ViewSignoff({ isNewSignoff, ...props }) {
   const classes = useStyles();
   const [channelTextValue, setChannelTextValue] = useState(channel || '');
   const [productTextValue, setProductTextValue] = useState(product || '');
+  const [selectedItems, setSelectedItems] = useState([]);
   const [type, setType] = useState(channel ? 'channel' : 'permission');
   const [roles, setRoles] = useState([]);
   const [originalRoles, setOriginalRoles] = useState([]);
@@ -163,6 +164,9 @@ function ViewSignoff({ isNewSignoff, ...props }) {
 
   // TODO: Add delete logic
   const handleSignoffDelete = () => {};
+  const handleSelectedItemsChange = chips => {
+    setSelectedItems(chips);
+  };
 
   useEffect(() => {
     if (isNewSignoff) {
@@ -228,6 +232,9 @@ function ViewSignoff({ isNewSignoff, ...props }) {
             <Grid container spacing={2}>
               <Grid item xs={12}>
                 <AutoCompleteText
+                  multi
+                  selectedItems={selectedItems}
+                  onSelectedItemsChange={handleSelectedItemsChange}
                   onValueChange={handleProductChange}
                   value={productTextValue}
                   getSuggestions={
```