### PR TITLE
Rename component: Rule -> Role

### DIFF
--- a/src/views/Roles/ListRoles/index.jsx
+++ b/src/views/Roles/ListRoles/index.jsx
@@ -33,7 +33,7 @@ const useStyles = makeStyles(theme => ({
   },
 }));
 
-function ListRules() {
+function ListRoles() {
   const classes = useStyles();
   const [usersAction, fetchUsers] = useAction(getUsers);
   const [roleFilter, setRoleFilter] = useState(ALL);
@@ -124,4 +124,4 @@ function ListRules() {
   );
 }
 
-export default ListRules;
+export default ListRoles;

--- a/src/views/Roles/index.jsx
+++ b/src/views/Roles/index.jsx
@@ -3,7 +3,7 @@ import { Switch } from 'react-router-dom';
 import RouteWithProps from '../../components/RouteWithProps';
 import routes from './routes';
 
-export default function Rules(props) {
+export default function Roles(props) {
   const {
     match: { path },
   } = props;


### PR DESCRIPTION
I noticed `ListRoles` and `Roles` components were named `ListRules` and `Rules`. Guess they were copied from `rules/` but weren't renamed.

/cc @helfi92 