### PR TITLE
Implement user mutations

### DIFF
--- a/src/services/users.js
+++ b/src/services/users.js
@@ -2,5 +2,22 @@ import axios from 'axios';
 
 const getUsers = () => axios.get('/users');
 const getUserInfo = username => axios.get(`/users/${username}`);
+const addRole = (username, role) =>
+  axios.put(`/users/${username}/roles/${role}`);
+const removeRole = (username, role, dataVersion) =>
+  axios.delete(`/users/${username}/roles/${role}`, {
+    params: { data_version: dataVersion },
+  });
+const addPermission = (username, permission, options) => {};
+const updatePermission = (username, permission, ...postData) => {};
+const deletePermission = (username, permission, dataVersion) => {};
 
-export { getUsers, getUserInfo };
+export {
+  getUsers,
+  getUserInfo,
+  addRole,
+  removeRole,
+  addPermission,
+  updatePermission,
+  deletePermission,
+};

--- a/src/services/users.js
+++ b/src/services/users.js
@@ -9,41 +9,45 @@ const removeRole = (username, role, dataVersion) =>
   axios.delete(`/users/${username}/roles/${role}`, {
     params: { data_version: dataVersion },
   });
-const addScheduledPermissionChange = ({ username, permission, options, dataVersion, changeType, when }) =>
-  axios.post(
-    '/scheduled_changes/permissions',
-    {
-      username,
-      permission,
-      data_version: dataVersion,
-      options: JSON.stringify(options),
-      change_type: changeType,
-      when,
-    }
-  );
-
-const updateScheduledPermissionChange = ({ username, permission, options, dataVersion, scId, scDataVersion, when }) =>
-  axios.post(
-    `/scheduled_changes/permissions/${scId}`,
-    {
-      username,
-      permission,
-      data_version: dataVersion,
-      options: JSON.stringify(options),
-      sc_data_version: scDataVersion,
-      when,
-    },
-  );
-
+const addScheduledPermissionChange = ({
+  username,
+  permission,
+  options,
+  dataVersion,
+  changeType,
+  when,
+}) =>
+  axios.post('/scheduled_changes/permissions', {
+    username,
+    permission,
+    data_version: dataVersion,
+    options: JSON.stringify(options),
+    change_type: changeType,
+    when,
+  });
+const updateScheduledPermissionChange = ({
+  username,
+  permission,
+  options,
+  dataVersion,
+  scId,
+  scDataVersion,
+  when,
+}) =>
+  axios.post(`/scheduled_changes/permissions/${scId}`, {
+    username,
+    permission,
+    data_version: dataVersion,
+    options: JSON.stringify(options),
+    sc_data_version: scDataVersion,
+    when,
+  });
 const deleteScheduledPermissionChange = ({ scId, scDataVersion }) =>
-  axios.delete(
-    `/scheduled_changes/permissions/${scId}`,
-    {
-      params: {
-        data_version: scDataVersion,
-      }
+  axios.delete(`/scheduled_changes/permissions/${scId}`, {
+    params: {
+      data_version: scDataVersion,
     },
-  );
+  });
 
 export {
   getUsers,

--- a/src/services/users.js
+++ b/src/services/users.js
@@ -9,16 +9,6 @@ const removeRole = (username, role, dataVersion) =>
   axios.delete(`/users/${username}/roles/${role}`, {
     params: { data_version: dataVersion },
   });
-const addPermission = ({ username, permission, options }) => {};
-const updatePermission = ({ username, permission, options, dataVersion }) =>
-  axios.put(
-    `/users/${username}/permissions/${permission}`,
-    {
-      options: JSON.stringify(options),
-      data_version: dataVersion,
-    }
-  );
-const deletePermission = ({ username, permission, dataVersion }) => {};
 const addScheduledPermissionChange = ({ username, permission, options, dataVersion, changeType, when }) =>
   axios.post(
     '/scheduled_changes/permissions',
@@ -45,15 +35,23 @@ const updateScheduledPermissionChange = ({ username, permission, options, dataVe
     },
   );
 
+const deleteScheduledPermissionChange = ({ scId, scDataVersion }) =>
+  axios.delete(
+    `/scheduled_changes/permissions/${scId}`,
+    {
+      params: {
+        data_version: scDataVersion,
+      }
+    },
+  );
+
 export {
   getUsers,
   getUserInfo,
   getScheduledChanges,
   addRole,
   removeRole,
-  addPermission,
-  updatePermission,
-  deletePermission,
   addScheduledPermissionChange,
   updateScheduledPermissionChange,
+  deleteScheduledPermissionChange,
 };

--- a/src/services/users.js
+++ b/src/services/users.js
@@ -8,9 +8,41 @@ const removeRole = (username, role, dataVersion) =>
   axios.delete(`/users/${username}/roles/${role}`, {
     params: { data_version: dataVersion },
   });
-const addPermission = (username, permission, options) => {};
-const updatePermission = (username, permission, ...postData) => {};
-const deletePermission = (username, permission, dataVersion) => {};
+const addPermission = ({ username, permission, options }) => {};
+const updatePermission = ({ username, permission, options, dataVersion }) =>
+  axios.put(
+    `/users/${username}/permissions/${permission}`,
+    {
+      options: JSON.stringify(options),
+      data_version: dataVersion,
+    }
+  );
+const deletePermission = ({ username, permission, dataVersion }) => {};
+const addScheduledPermissionChange = ({ username, permission, options, dataVersion, changeType, when }) =>
+  axios.post(
+    '/scheduled_changes/permissions',
+    {
+      username,
+      permission,
+      data_version: dataVersion,
+      options: JSON.stringify(options),
+      change_type: changeType,
+      when,
+    }
+  );
+
+const updateScheduledPermissionChange = ({ username, permission, options, dataVersion, scId, scDataVersion, when }) =>
+  axios.post(
+    `/scheduled_changes/permissions/${scId}`,
+    {
+      username,
+      permission,
+      data_version: dataVersion,
+      options: JSON.stringify(options),
+      sc_data_version: scDataVersion,
+      when,
+    },
+  );
 
 export {
   getUsers,
@@ -20,4 +52,6 @@ export {
   addPermission,
   updatePermission,
   deletePermission,
+  addScheduledPermissionChange,
+  updateScheduledPermissionChange,
 };

--- a/src/services/users.js
+++ b/src/services/users.js
@@ -2,6 +2,7 @@ import axios from 'axios';
 
 const getUsers = () => axios.get('/users');
 const getUserInfo = username => axios.get(`/users/${username}`);
+const getScheduledChanges = () => axios.get('/scheduled_changes/permissions');
 const addRole = (username, role) =>
   axios.put(`/users/${username}/roles/${role}`);
 const removeRole = (username, role, dataVersion) =>
@@ -47,6 +48,7 @@ const updateScheduledPermissionChange = ({ username, permission, options, dataVe
 export {
   getUsers,
   getUserInfo,
+  getScheduledChanges,
   addRole,
   removeRole,
   addPermission,

--- a/src/views/Users/ViewUser/index.jsx
+++ b/src/views/Users/ViewUser/index.jsx
@@ -55,7 +55,7 @@ const useStyles = makeStyles(theme => ({
 }));
 
 function ViewUser({ isNewUser, ...props }) {
-  const getEmptyPermission = additional => ({
+  const getEmptyPermission = (additional = false) => ({
     name: '',
     options: {
       products: [],
@@ -156,7 +156,9 @@ function ViewUser({ isNewUser, ...props }) {
               sc[0].name = sc[0].permission;
               delete sc[0].permission;
 
-              [permission.sc] = sc;
+              // Array destructuring is not very readable here.
+              // eslint-disable-next-line prefer-destructuring
+              permission.sc = sc[0];
             }
 
             return permission;
@@ -167,7 +169,7 @@ function ViewUser({ isNewUser, ...props }) {
         // with, so we need to create an empty one, and add to it.
         scheduledChanges.data.data.scheduled_changes.forEach(sc => {
           if (sc.change_type === 'insert') {
-            const p = getEmptyPermission(false);
+            const p = getEmptyPermission();
 
             p.name = sc.permission;
             p.sc = clone(sc);
@@ -472,7 +474,7 @@ function ViewUser({ isNewUser, ...props }) {
                 disabled={saveAction.loading}
                 icon={<DeleteIcon />}
                 tooltipOpen
-                tooltipTitle="Delete Signoff"
+                tooltipTitle="Delete User"
                 onClick={handleUserDelete}
               />
             </SpeedDial>

--- a/src/views/Users/ViewUser/index.jsx
+++ b/src/views/Users/ViewUser/index.jsx
@@ -28,6 +28,7 @@ import {
   supportsActionRestriction,
   getSupportedActions,
 } from '../../../utils/userUtils';
+import updateUser from '../utils/updateUser';
 
 const useStyles = makeStyles(theme => ({
   fab: {
@@ -93,7 +94,7 @@ function ViewUser({ isNewUser, ...props }) {
   const [productsAction, fetchProducts] = useAction(getProducts);
   const [userAction, fetchUser] = useAction(getUserInfo);
   // eslint-disable-next-line no-unused-vars
-  const [saveAction, saveUser] = useAction(() => {});
+  const [saveAction, saveUser] = useAction(updateUser);
   const isLoading = userAction.loading || productsAction.loading;
   const error = userAction.error || productsAction.error || saveAction.error;
   const defaultToEmptyString = defaultTo('');
@@ -238,7 +239,22 @@ function ViewUser({ isNewUser, ...props }) {
       : setPermissions(permissions.map(updateText));
   };
 
-  const handleUserSave = () => {};
+  const handleUserSave = async () => {
+    const { error } = await saveUser({
+      username,
+      roles,
+      originalRoles,
+      additionalRoles,
+      permissions,
+      originalPermissions,
+      additionalPermissions,
+    });
+
+    if (!error) {
+      props.history.push('/users');
+    }
+  };
+
   const handleUserDelete = () => {};
   const renderRole = (role, index) => (
     <Grid container spacing={2} key={index}>

--- a/src/views/Users/ViewUser/index.jsx
+++ b/src/views/Users/ViewUser/index.jsx
@@ -350,7 +350,7 @@ function ViewUser({ isNewUser, ...props }) {
         <AutoCompleteText
           multi
           disabled={
-            permission.sc.change_type === 'delete' ||
+            permission.sc && permission.sc.change_type === 'delete' ||
             !supportsProductRestriction(
               permission.sc ? permission.sc.name : permission.name
             )
@@ -374,7 +374,7 @@ function ViewUser({ isNewUser, ...props }) {
         <AutoCompleteText
           multi
           disabled={
-            permission.sc.change_type === 'delete' ||
+            permission.sc && permission.sc.change_type === 'delete' ||
             !supportsActionRestriction(
               permission.sc ? permission.sc.name : permission.name
             )

--- a/src/views/Users/ViewUser/index.jsx
+++ b/src/views/Users/ViewUser/index.jsx
@@ -61,7 +61,7 @@ function ViewUser({ isNewUser, ...props }) {
       products: [],
       actions: [],
     },
-    scheduledChange: {},
+    sc: null,
     metadata: {
       isAdditional: true,
       productText: '',
@@ -133,7 +133,7 @@ function ViewUser({ isNewUser, ...props }) {
               name,
               options: details.options || { products: [], actions: [] },
               data_version: details.data_version,
-              scheduledChange: {},
+              sc: null,
               metadata: {
                 isAdditional: false,
                 productText: '',
@@ -144,7 +144,7 @@ function ViewUser({ isNewUser, ...props }) {
             if (sc) {
               sc[0].name = sc[0].permission;
               delete sc[0].permission;
-              permission.scheduledChange = sc[0];
+              permission.sc = sc[0];
             }
 
             return permission;
@@ -161,7 +161,6 @@ function ViewUser({ isNewUser, ...props }) {
       });
     }
   }, []);
-  console.log(permissions);
 
   const handleUsernameChange = ({ target: { value } }) => setUsername(value);
   const handleRoleNameChange = (role, index, value) => {
@@ -236,7 +235,9 @@ function ViewUser({ isNewUser, ...props }) {
 
       const result = entry;
 
-      result.options[restriction] = chips;
+      result.sc
+        ? result.sc.options[restriction] = chips
+        : result.options[restriction] = chips;
 
       return result;
     };
@@ -305,8 +306,8 @@ function ViewUser({ isNewUser, ...props }) {
     <Grid container spacing={2} key={index}>
       <Grid item xs={3}>
         <AutoCompleteText
-          value={defaultToEmptyString(permission.name)}
-          onValueChange={handlePermissionNameChange(permission, index)}
+          value={defaultToEmptyString(permission.sc ? permission.sc.name : permission.name)}
+          onValueChange={handlePermissionNameChange(permission.sc || permission, index)}
           getSuggestions={getSuggestions(ALL_PERMISSIONS)}
           label="Name"
           required
@@ -316,8 +317,8 @@ function ViewUser({ isNewUser, ...props }) {
       <Grid item xs={4}>
         <AutoCompleteText
           multi
-          disabled={!supportsProductRestriction(permission.name)}
-          selectedItems={permission.options.products}
+          disabled={!supportsProductRestriction(permission.sc ? permission.sc.name : permission.name)}
+          selectedItems={permission.sc ? permission.sc.options.products : permission.options.products}
           onSelectedItemsChange={handleRestrictionChange(
             permission,
             'products'
@@ -331,8 +332,8 @@ function ViewUser({ isNewUser, ...props }) {
       <Grid item xs={4}>
         <AutoCompleteText
           multi
-          disabled={!supportsActionRestriction(permission.name)}
-          selectedItems={permission.options.actions}
+          disabled={!supportsActionRestriction(permission.sc ? permission.sc.name : permission.name)}
+          selectedItems={permission.sc ? permission.sc.options.actions : permission.options.actions}
           onSelectedItemsChange={handleRestrictionChange(permission, 'actions')}
           onValueChange={handleRestrictionTextChange(permission, 'actionText')}
           value={permission.metadata.actionText}

--- a/src/views/Users/ViewUser/index.jsx
+++ b/src/views/Users/ViewUser/index.jsx
@@ -311,7 +311,25 @@ function ViewUser({ isNewUser, ...props }) {
     }
   };
 
-  const handleUserDelete = () => {};
+  const handleUserDelete = async () => {
+    // We can use the existing saveUser function to delete a user
+    // as long as we set current/additional roles and permissions
+    // to empty arrays.
+    const { error } = await saveUser({
+      username,
+      roles: [],
+      originalRoles,
+      additionalRoles: [],
+      permissions: [],
+      originalPermissions,
+      additionalPermissions: [],
+    });
+
+    if (!error) {
+      props.history.push('/users');
+    }
+  };
+
   const renderRole = (role, index) => (
     <Grid container spacing={2} key={index}>
       <Grid item xs={11}>

--- a/src/views/Users/ViewUser/index.jsx
+++ b/src/views/Users/ViewUser/index.jsx
@@ -55,7 +55,7 @@ const useStyles = makeStyles(theme => ({
 }));
 
 function ViewUser({ isNewUser, ...props }) {
-  const getEmptyPermission = () => ({
+  const getEmptyPermission = additional => ({
     name: '',
     options: {
       products: [],
@@ -63,7 +63,7 @@ function ViewUser({ isNewUser, ...props }) {
     },
     sc: null,
     metadata: {
-      isAdditional: true,
+      isAdditional: additional,
       productText: '',
       actionText: '',
     },
@@ -90,7 +90,7 @@ function ViewUser({ isNewUser, ...props }) {
   // eslint-disable-next-line no-unused-vars
   const [originalPermissions, setOriginalPermissions] = useState([]);
   const [additionalPermissions, setAdditionalPermissions] = useState(
-    isNewUser ? [getEmptyPermission()] : []
+    isNewUser ? [getEmptyPermission(true)] : []
   );
   const [products, setProducts] = useState([]);
   // TODO: show pending changes, signoffs, and allow them to be signed off
@@ -162,13 +162,14 @@ function ViewUser({ isNewUser, ...props }) {
           }
         );
 
-        scheduledChanges.data.data.scheduled_changes.map(sc => {
+        scheduledChanges.data.data.scheduled_changes.forEach(sc => {
           if (sc.change_type === 'insert') {
-            const p = getEmptyPermission();
+            const p = getEmptyPermission(false);
+
             p.name = sc.permission;
-            sc.name = sc.permission;
-            delete sc.permission;
-            p.sc = sc;
+            p.sc = clone(sc);
+            p.sc.name = sc.permission;
+            delete p.sc.permission;
             permissions.push(p);
           }
         });
@@ -219,7 +220,7 @@ function ViewUser({ isNewUser, ...props }) {
 
   const handlePermissionAdd = () => {
     setAdditionalPermissions(
-      additionalPermissions.concat([getEmptyPermission()])
+      additionalPermissions.concat([getEmptyPermission(true)])
     );
   };
 

--- a/src/views/Users/ViewUser/index.jsx
+++ b/src/views/Users/ViewUser/index.jsx
@@ -162,6 +162,17 @@ function ViewUser({ isNewUser, ...props }) {
           }
         );
 
+        scheduledChanges.data.data.scheduled_changes.map(sc => {
+          if (sc.change_type === 'insert') {
+            const p = getEmptyPermission();
+            p.name = sc.permission;
+            sc.name = sc.permission;
+            delete sc.permission;
+            p.sc = sc;
+            permissions.push(p);
+          }
+        });
+
         setUsername(userdata.data.data.username);
         setRoles(roles);
         setOriginalRoles(clone(roles));

--- a/src/views/Users/ViewUser/index.jsx
+++ b/src/views/Users/ViewUser/index.jsx
@@ -141,7 +141,7 @@ function ViewUser({ isNewUser, ...props }) {
               },
             };
 
-            if (sc) {
+            if (sc.length > 0) {
               sc[0].name = sc[0].permission;
               delete sc[0].permission;
               if (!Object.keys(sc[0].options).includes('actions')) {

--- a/src/views/Users/ViewUser/index.jsx
+++ b/src/views/Users/ViewUser/index.jsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState, Fragment } from 'react';
 import { bool } from 'prop-types';
-import { clone, defaultTo } from 'ramda';
+import { clone, defaultTo, propOr } from 'ramda';
 import { makeStyles } from '@material-ui/styles';
 import Grid from '@material-ui/core/Grid';
 import TextField from '@material-ui/core/TextField';
@@ -151,7 +151,10 @@ function ViewUser({ isNewUser, ...props }) {
               sc[0].name = sc[0].permission;
               delete sc[0].permission;
 
-              if (!Object.keys(sc[0].options).includes('actions')) {
+              if (
+                sc[0].options &&
+                !Object.keys(sc[0].options).includes('actions')
+              ) {
                 sc[0].options.actions = [];
               }
 
@@ -347,13 +350,14 @@ function ViewUser({ isNewUser, ...props }) {
         <AutoCompleteText
           multi
           disabled={
+            permission.sc.change_type === 'delete' ||
             !supportsProductRestriction(
               permission.sc ? permission.sc.name : permission.name
             )
           }
           selectedItems={
             permission.sc
-              ? permission.sc.options.products
+              ? propOr([], 'products')(permission.sc.options)
               : permission.options.products
           }
           onSelectedItemsChange={handleRestrictionChange(
@@ -370,13 +374,14 @@ function ViewUser({ isNewUser, ...props }) {
         <AutoCompleteText
           multi
           disabled={
+            permission.sc.change_type === 'delete' ||
             !supportsActionRestriction(
               permission.sc ? permission.sc.name : permission.name
             )
           }
           selectedItems={
             permission.sc
-              ? permission.sc.options.actions
+              ? propOr([], 'actions')(permission.sc.options)
               : permission.options.actions
           }
           onSelectedItemsChange={handleRestrictionChange(permission, 'actions')}
@@ -386,6 +391,9 @@ function ViewUser({ isNewUser, ...props }) {
           label="Action Restrictions"
         />
       </Grid>
+      {/* TODO: This delete button functions weirdly when a permission
+          is scheduled to be deleted. If used, it will _cancel_ the
+          deletion. Need to find a better way to handle this. */}
       <Grid item xs={1} className={classes.gridDelete}>
         <IconButton
           className={classes.iconButton}

--- a/src/views/Users/ViewUser/index.jsx
+++ b/src/views/Users/ViewUser/index.jsx
@@ -147,16 +147,14 @@ function ViewUser({ isNewUser, ...props }) {
               },
             };
 
+            // Copy any scheduled changes associated with an existing
+            // permission into the list of permissions.
             if (sc.length > 0) {
+              // The backend refers to permission names as the 'permission'
+              // attribute of an object, but we prefer to call it 'name', so
+              // we have to adjust that.
               sc[0].name = sc[0].permission;
               delete sc[0].permission;
-
-              if (
-                sc[0].options &&
-                !Object.keys(sc[0].options).includes('actions')
-              ) {
-                sc[0].options.actions = [];
-              }
 
               [permission.sc] = sc;
             }
@@ -165,6 +163,8 @@ function ViewUser({ isNewUser, ...props }) {
           }
         );
 
+        // Scheduled inserts don't have an existing permission to associate
+        // with, so we need to create an empty one, and add to it.
         scheduledChanges.data.data.scheduled_changes.forEach(sc => {
           if (sc.change_type === 'insert') {
             const p = getEmptyPermission(false);
@@ -350,7 +350,7 @@ function ViewUser({ isNewUser, ...props }) {
         <AutoCompleteText
           multi
           disabled={
-            permission.sc && permission.sc.change_type === 'delete' ||
+            (permission.sc && permission.sc.change_type === 'delete') ||
             !supportsProductRestriction(
               permission.sc ? permission.sc.name : permission.name
             )
@@ -374,7 +374,7 @@ function ViewUser({ isNewUser, ...props }) {
         <AutoCompleteText
           multi
           disabled={
-            permission.sc && permission.sc.change_type === 'delete' ||
+            (permission.sc && permission.sc.change_type === 'delete') ||
             !supportsActionRestriction(
               permission.sc ? permission.sc.name : permission.name
             )

--- a/src/views/Users/ViewUser/index.jsx
+++ b/src/views/Users/ViewUser/index.jsx
@@ -144,6 +144,9 @@ function ViewUser({ isNewUser, ...props }) {
             if (sc) {
               sc[0].name = sc[0].permission;
               delete sc[0].permission;
+              if (!Object.keys(sc[0].options).includes('actions')) {
+                sc[0].options.actions = [];
+              }
               permission.sc = sc[0];
             }
 

--- a/src/views/Users/utils/updateUser.js
+++ b/src/views/Users/utils/updateUser.js
@@ -52,7 +52,7 @@ export default params => {
           return;
         }
 
-        if (equals(permission.options, permission.sc.options)) {
+        if (permission.sc && equals(permission.options, permission.sc.options)) {
           return deleteScheduledPermissionChange({
             scId: permission.sc.sc_id,
             scDataVersion: permission.sc.sc_data_version,
@@ -70,8 +70,9 @@ export default params => {
             permission: permission.name,
             options,
             dataVersion: permission.data_version,
-            scId: permission.sc_id,
-            scDataVersion: permission.data_version,
+            scId: permission.sc.sc_id,
+            scDataVersion: permission.sc.data_version,
+            when: new Date().getTime() + 5000,
           });
         }
 

--- a/src/views/Users/utils/updateUser.js
+++ b/src/views/Users/utils/updateUser.js
@@ -17,7 +17,6 @@ export default params => {
     permissions,
     originalPermissions,
     additionalPermissions,
-    requiredSignoffs,
   } = params;
   const currentRoles = roles.map(role => role.name);
   const removedRoles = originalRoles.filter(
@@ -28,9 +27,6 @@ export default params => {
     p => !currentPermissions.includes(p.name)
   );
 
-  // TODO: need to add support for grabbing scheduled permission changes to ViewUser
-  // and figure out where those will be in the data structure. maybe compare to the rules
-  // edit page to figure it out?
   return Promise.all(
     [].concat(
       additionalRoles.map(role => addRole(username, role.name)),
@@ -39,11 +35,17 @@ export default params => {
       ),
       permissions.map(permission => {
         let skip = false;
+
         originalPermissions.forEach(value => {
-          const newOptions = permission.sc ? permission.sc.options : permission.options;
+          const newOptions = permission.sc
+            ? permission.sc.options
+            : permission.options;
           const originalOptions = value.sc ? value.sc.options : value.options;
 
-          if (value.name === permission.name && equals(newOptions, originalOptions)) {
+          if (
+            value.name === permission.name &&
+            equals(newOptions, originalOptions)
+          ) {
             skip = true;
           }
         });
@@ -52,16 +54,26 @@ export default params => {
           return;
         }
 
-        if (permission.sc && equals(permission.options, permission.sc.options)) {
+        if (
+          permission.sc &&
+          equals(permission.options, permission.sc.options)
+        ) {
           return deleteScheduledPermissionChange({
             scId: permission.sc.sc_id,
             scDataVersion: permission.sc.sc_data_version,
           });
         }
 
-        const options = {products: permission.sc ? permission.sc.options.products : permission.options.products}
+        const options = {
+          products: permission.sc
+            ? permission.sc.options.products
+            : permission.options.products,
+        };
+
         if (supportsActionRestriction(permission.name)) {
-          options.actions = permission.sc ? permission.sc.options.actions : permission.options.actions;
+          options.actions = permission.sc
+            ? permission.sc.options.actions
+            : permission.options.actions;
         }
 
         if (permission.sc) {

--- a/src/views/Users/utils/updateUser.js
+++ b/src/views/Users/utils/updateUser.js
@@ -1,0 +1,26 @@
+import { addRole, removeRole } from '../../../services/users';
+
+export default params => {
+  const {
+    username,
+    roles,
+    originalRoles,
+    additionalRoles,
+    permissions,
+    originalPermissions,
+    additionalPermissions,
+  } = params;
+  const currentRoles = roles.map(role => role.name);
+  const removedRoles = originalRoles.filter(
+    role => !currentRoles.includes(role.name)
+  );
+
+  return Promise.all(
+    [].concat(
+      additionalRoles.map(role => addRole(username, role.name)),
+      removedRoles.map(role =>
+        removeRole(username, role.name, role.data_version)
+      )
+    )
+  );
+};

--- a/src/views/Users/utils/updateUser.js
+++ b/src/views/Users/utils/updateUser.js
@@ -112,7 +112,22 @@ export default params => {
           when: new Date().getTime() + 5000,
         });
       }),
-      removedPermissions.map(permission => {})
+      removedPermissions.map(permission => {
+        if (permission.sc) {
+          return deleteScheduledPermissionChange({
+            scId: permission.sc.sc_id,
+            scDataVersion: permission.sc.sc_data_version,
+          });
+        }
+
+        return addScheduledPermissionChange({
+          username,
+          permission: permission.name,
+          dataVersion: permission.data_version,
+          changeType: 'delete',
+          when: new Date().getTime() + 5000,
+        });
+      })
     )
   );
 };

--- a/src/views/Users/utils/updateUser.js
+++ b/src/views/Users/utils/updateUser.js
@@ -1,4 +1,10 @@
-import { addRole, removeRole } from '../../../services/users';
+import {
+  addRole,
+  removeRole,
+  addPermission,
+  updatePermission,
+  deletePermission,
+} from '../../../services/users';
 
 export default params => {
   const {
@@ -9,10 +15,15 @@ export default params => {
     permissions,
     originalPermissions,
     additionalPermissions,
+    requiredSignoffs,
   } = params;
   const currentRoles = roles.map(role => role.name);
   const removedRoles = originalRoles.filter(
     role => !currentRoles.includes(role.name)
+  );
+  const currentPermissions = permissions.map(p => p.name);
+  const removedPermissions = originalPermissions.filter(
+    p => !currentPermissions.includes(p.name)
   );
 
   return Promise.all(
@@ -20,7 +31,10 @@ export default params => {
       additionalRoles.map(role => addRole(username, role.name)),
       removedRoles.map(role =>
         removeRole(username, role.name, role.data_version)
-      )
+      ),
+      permissions.map(permission => {}),
+      additionalPermissions.map(permission => {}),
+      removedPermissions.map(permission => {})
     )
   );
 };

--- a/src/views/Users/utils/updateUser.js
+++ b/src/views/Users/utils/updateUser.js
@@ -1,10 +1,14 @@
+import { equals } from 'ramda';
 import {
   addRole,
   removeRole,
   addPermission,
   updatePermission,
   deletePermission,
+  addScheduledPermissionChange,
+  updateScheduledPermissionChange,
 } from '../../../services/users';
+import { supportsActionRestriction } from '../../../utils/userUtils';
 
 export default params => {
   const {
@@ -26,13 +30,82 @@ export default params => {
     p => !currentPermissions.includes(p.name)
   );
 
+  const requiresSignoff = (permission, productRestrictions, originalRestrictions) => {
+    return requiredSignoffs.some(rs => {
+      if (!productRestrictions.length || productRestrictions.includes(rs.product)) {
+        return true;
+      }
+
+      if (!originalRestrictions.length || originalRestrictions.includes(rs.original)) {
+        return true;
+      }
+
+      return false;
+    });
+  };
+
+  // TODO: need to add support for grabbing scheduled permission changes to ViewUser
+  // and figure out where those will be in the data structure. maybe compare to the rules
+  // edit page to figure it out?
   return Promise.all(
     [].concat(
       additionalRoles.map(role => addRole(username, role.name)),
       removedRoles.map(role =>
         removeRole(username, role.name, role.data_version)
       ),
-      permissions.map(permission => {}),
+      permissions.map(permission => {
+        console.log(`Processing ${permission.name}`);
+        console.log(permission);
+        const originalPermission = originalPermissions.filter(p => p.name === permission.name)[0];
+        const useScheduledChange = permission.scheduledChange || requiresSignoff(permission.name, permission.options.products, originalPermission.options.products);
+        // todo: can permission.options be null?
+        const options = {products: permission.options.products}
+        if (supportsActionRestriction(permission.name)) {
+          options.actions = permission.options.actions;
+        }
+        let skip = false;
+
+        originalPermissions.forEach(value => {
+          // if permissions are the same, set skip to true
+          // not sure if this condition will work
+          if (value.name === permission.name && equals(value.options, permission.options)) {
+            skip = true;
+          }
+        });
+
+        if (skip) {
+          return;
+        }
+        
+        if (useScheduledChange) {
+          if (permission.scheduledChange) {
+            return updateScheduledPermissionChange({
+              username,
+              permission: permission.name,
+              options,
+              dataVersion: permission.data_version,
+              scId: permission.scheduledChange.sc_id,
+              scDataVersion: permission.scheduledChange.data_version,
+            });
+          }
+
+          return addScheduledPermissionChange({
+            username,
+            permission: permission.name,
+            options,
+            dataVersion: permission.data_version,
+            changeType: 'update',
+            when: new Date().getTime() + 5000,
+          });
+        }
+
+        return updatePermission({
+          username,
+          permission: permission.name,
+          options,
+          dataVersion: permission.data_version,
+        });
+      }),
       additionalPermissions.map(permission => {}),
       removedPermissions.map(permission => {})
     )

--- a/src/views/Users/utils/updateUser.js
+++ b/src/views/Users/utils/updateUser.js
@@ -83,7 +83,7 @@ export default params => {
             options,
             dataVersion: permission.data_version,
             scId: permission.sc.sc_id,
-            scDataVersion: permission.sc.data_version,
+            scDataVersion: permission.sc.sc_data_version,
             when: new Date().getTime() + 5000,
           });
         }

--- a/src/views/Users/utils/updateUser.js
+++ b/src/views/Users/utils/updateUser.js
@@ -97,7 +97,21 @@ export default params => {
           when: new Date().getTime() + 5000,
         });
       }),
-      additionalPermissions.map(permission => {}),
+      additionalPermissions.map(permission => {
+        const options = { products: permission.options.products };
+
+        if (supportsActionRestriction(permission.name)) {
+          options.actions = permission.options.actions;
+        }
+
+        return addScheduledPermissionChange({
+          username,
+          permission: permission.name,
+          options,
+          changeType: 'insert',
+          when: new Date().getTime() + 5000,
+        });
+      }),
       removedPermissions.map(permission => {})
     )
   );


### PR DESCRIPTION
This implements all of the mutations on the ViewUser page. It also modifies this page to show the scheduled version of an object when it exists (like we did on the Required Signoffs page). This works well for the most part, because you're always seeing the desired or upcoming state of the User. However, there's a big rough edge when a permission is scheduled to be removed -- it shows up in the list of permissions, and if you remove it with the trash icon, you _cancel_ the removal. I can't really think of a good way to handle this at the moment, but it's something that needs to be addressed.

We also need to update the Users list to show pending changes, which is covered in #90 and #91.