### PR TITLE
Allow users to sign off on rule scheduled changes (fixes #62)

### DIFF
--- a/src/components/DialogAction/index.jsx
+++ b/src/components/DialogAction/index.jsx
@@ -37,6 +37,7 @@ function DialogAction(props) {
     confirmText,
     error,
     onClose,
+    onExited,
     onSubmit,
     onComplete,
     onError,
@@ -69,6 +70,7 @@ function DialogAction(props) {
     <Dialog
       classes={{ paper: classes.paper }}
       open={open}
+      onExited={(...props) => onExited && onExited(...props)}
       onClose={onClose}
       {...rest}>
       {title && <DialogTitle>{title}</DialogTitle>}
@@ -127,6 +129,7 @@ DialogAction.propTypes = {
   onError: func,
   /** Callback fired when the component requests to be closed. */
   onClose: func.isRequired,
+  onExited: func,
   /** Error to display. */
   error: oneOfType([string, object]),
   /**

--- a/src/components/RuleCard/index.jsx
+++ b/src/components/RuleCard/index.jsx
@@ -718,35 +718,51 @@ function RuleCard({
       </CardContent>
       {!readOnly && (
         <CardActions className={classes.cardActions}>
-          <Link
-            className={classes.link}
-            to={{
-              pathname: '/rules/create',
-              state: {
-                rule,
-              },
-            }}>
-            <Button color="secondary">Duplicate</Button>
-          </Link>
-          <Link
-            className={classes.link}
-            to={
-              rule.rule_id
-                ? `/rules/${rule.rule_id}`
-                : `/rules/create/${rule.scheduledChange.sc_id}`
-            }>
-            <Button color="secondary">Update</Button>
-          </Link>
-          <Button color="secondary" onClick={() => onRuleDelete(rule)}>
+          {user ? (
+            <Link
+              className={classes.link}
+              to={{
+                pathname: '/rules/create',
+                state: {
+                  rule,
+                },
+              }}>
+              <Button color="secondary">Duplicate</Button>
+            </Link>
+          ) : (
+            <Button color="secondary" disabled>
+              Duplicate
+            </Button>
+          )}
+          {user ? (
+            <Link
+              className={classes.link}
+              to={
+                rule.rule_id
+                  ? `/rules/${rule.rule_id}`
+                  : `/rules/create/${rule.scheduledChange.sc_id}`
+              }>
+              <Button color="secondary">Update</Button>
+            </Link>
+          ) : (
+            <Button color="secondary" disabled>
+              Update
+            </Button>
+          )}
+          <Button
+            color="secondary"
+            disabled={!user}
+            onClick={() => onRuleDelete(rule)}>
             Delete
           </Button>
-          {requiresSignoff &&
+          {!readOnly &&
+            requiresSignoff &&
             (user && user.email in rule.scheduledChange.signoffs ? (
-              <Button color="secondary" onClick={onRevoke}>
+              <Button color="secondary" disabled={!user} onClick={onRevoke}>
                 Revoke Signoff
               </Button>
             ) : (
-              <Button color="secondary" onClick={onSignoff}>
+              <Button color="secondary" disabled={!user} onClick={onSignoff}>
                 Signoff
               </Button>
             ))}

--- a/src/components/RuleCard/index.jsx
+++ b/src/components/RuleCard/index.jsx
@@ -751,8 +751,7 @@ function RuleCard({
             onClick={() => onRuleDelete(rule)}>
             Delete
           </Button>
-          {!readOnly &&
-            requiresSignoff &&
+          {requiresSignoff &&
             (user && user.email in rule.scheduledChange.signoffs ? (
               <Button color="secondary" disabled={!user} onClick={onRevoke}>
                 Revoke Signoff

--- a/src/components/RuleCard/index.jsx
+++ b/src/components/RuleCard/index.jsx
@@ -140,6 +140,8 @@ const useStyles = makeStyles(theme => ({
 function RuleCard({
   rule,
   onRuleDelete,
+  onSignoff,
+  onRevoke,
   user,
   readOnly,
   onAuthorize,
@@ -737,9 +739,9 @@ function RuleCard({
           </Button>
           {requiresSignoff &&
             (user && user.email in rule.scheduledChange.signoffs ? (
-              <Button color="secondary">Revoke Signoff</Button>
+              <Button color="secondary" onClick={onRevoke}>Revoke Signoff</Button>
             ) : (
-              <Button color="secondary">Signoff as</Button>
+              <Button color="secondary" onClick={onSignoff}>Signoff as</Button>
             ))}
         </CardActions>
       )}
@@ -752,6 +754,8 @@ RuleCard.propTypes = {
   onRuleDelete: func,
   // If true, the card will hide all buttons.
   readOnly: bool,
+  onSignoff: func.isRequired,
+  onRevoke: func.isRequired,
 };
 
 RuleCard.defaultProps = {

--- a/src/components/RuleCard/index.jsx
+++ b/src/components/RuleCard/index.jsx
@@ -739,9 +739,13 @@ function RuleCard({
           </Button>
           {requiresSignoff &&
             (user && user.email in rule.scheduledChange.signoffs ? (
-              <Button color="secondary" onClick={onRevoke}>Revoke Signoff</Button>
+              <Button color="secondary" onClick={onRevoke}>
+                Revoke Signoff
+              </Button>
             ) : (
-              <Button color="secondary" onClick={onSignoff}>Signoff as</Button>
+              <Button color="secondary" onClick={onSignoff}>
+                Signoff
+              </Button>
             ))}
         </CardActions>
       )}

--- a/src/components/RuleCard/index.jsx
+++ b/src/components/RuleCard/index.jsx
@@ -772,8 +772,9 @@ RuleCard.propTypes = {
   onRuleDelete: func,
   // If true, the card will hide all buttons.
   readOnly: bool,
-  onSignoff: func.isRequired,
-  onRevoke: func.isRequired,
+  // These are required if readOnly is false
+  onSignoff: func,
+  onRevoke: func,
 };
 
 RuleCard.defaultProps = {

--- a/src/services/requiredSignoffs.js
+++ b/src/services/requiredSignoffs.js
@@ -23,17 +23,10 @@ const deleteRequiredSignoff = params => {
   });
 };
 
-const signoffRequiredSignoff = ({ type, scId, role }) =>
-  axios.post(`/scheduled_changes/${type}/${scId}/signoffs`, { role });
-const revokeRequiredSignoff = ({ type, scId }) =>
-  axios.delete(`/scheduled_changes/${type}/${scId}/signoffs`);
-
 // requiredSignoffs factory
 export {
   getRequiredSignoffs,
   getScheduledChanges,
   updateRequiredSignoff,
   deleteRequiredSignoff,
-  signoffRequiredSignoff,
-  revokeRequiredSignoff,
 };

--- a/src/services/signoffs.js
+++ b/src/services/signoffs.js
@@ -1,0 +1,8 @@
+import axios from 'axios';
+
+const makeSignoff = ({ type, scId, role }) =>
+  axios.post(`/scheduled_changes/${type}/${scId}/signoffs`, { role });
+const revokeSignoff = ({ type, scId }) =>
+  axios.delete(`/scheduled_changes/${type}/${scId}/signoffs`);
+
+export { makeSignoff, revokeSignoff };

--- a/src/views/RequiredSignoffs/ListSignoffs/index.jsx
+++ b/src/views/RequiredSignoffs/ListSignoffs/index.jsx
@@ -20,10 +20,7 @@ import DialogAction from '../../../components/DialogAction';
 import SignoffCard from '../../../components/SignoffCard';
 import ErrorPanel from '../../../components/ErrorPanel';
 import SignoffCardEntry from '../../../components/SignoffCardEntry';
-import {
-  signoffRequiredSignoff,
-  revokeRequiredSignoff,
-} from '../../../services/requiredSignoffs';
+import { makeSignoff, revokeSignoff } from '../../../services/signoffs';
 import { getUserInfo } from '../../../services/users';
 import Link from '../../../utils/Link';
 import getRequiredSignoffs from '../utils/getRequiredSignoffs';
@@ -72,8 +69,8 @@ function ListSignoffs({ user }) {
   const [signoffRole, setSignoffRole] = useState('');
   const [dialogState, setDialogState] = useState(DIALOG_ACTION_INITIAL_STATE);
   const [getRSAction, getRS] = useAction(getRequiredSignoffs);
-  const [signoffAction, signoff] = useAction(signoffRequiredSignoff);
-  const [revokeAction, revoke] = useAction(revokeRequiredSignoff);
+  const [signoffAction, signoff] = useAction(makeSignoff);
+  const [revokeAction, revoke] = useAction(revokeSignoff);
   const [rolesAction, getRoles] = useAction(getUserInfo);
   const loading = getRSAction.loading || rolesAction.loading;
   const error =

--- a/src/views/Rules/ListRules/index.jsx
+++ b/src/views/Rules/ListRules/index.jsx
@@ -334,8 +334,8 @@ function ListRules(props) {
     handleDialogClose();
   };
 
-  const handleDeleteDialogSubmit = async () => {
-    const dialogRule = dialogState.item;
+  const handleDeleteDialogSubmit = async state => {
+    const dialogRule = state.item;
     const { error } = await delRule({
       ruleId: dialogRule.rule_id,
       dataVersion: dialogRule.data_version,
@@ -411,9 +411,8 @@ function ListRules(props) {
     return { error, result: { signoffRole, rule } };
   };
 
-  const handleSignoffDialogSubmit = async () => {
-    console.log(dialogState);
-    const { error, result } = await doSignoff(signoffRole, dialogState.item);
+  const handleSignoffDialogSubmit = async state => {
+    const { error, result } = await doSignoff(signoffRole, state.item);
 
     if (error) {
       throw error;
@@ -690,7 +689,7 @@ function ListRules(props) {
         destructive={dialogState.destructive}
         body={dialogState.body}
         confirmText={dialogState.confirmText}
-        onSubmit={dialogState.handleSubmit}
+        onSubmit={() => dialogState.handleSubmit(dialogState)}
         onError={handleDialogError}
         error={dialogState.error}
         onComplete={dialogState.handleComplete}

--- a/src/views/Rules/ListRules/index.jsx
+++ b/src/views/Rules/ListRules/index.jsx
@@ -387,7 +387,7 @@ function ListRules(props) {
   const updateSignoffs = ({ signoffRole, rule }) => {
     setRulesWithScheduledChanges(
       rulesWithScheduledChanges.map(r => {
-        if (r.rule_id !== rule.rule_id) {
+        if (!r.scheduledChange || r.scheduledChange.sc_id !== rule.scheduledChange.sc_id) {
           return r;
         }
 
@@ -400,7 +400,6 @@ function ListRules(props) {
     );
   };
 
-  // TODO: this changes the state for all pending inserts at the same time
   const doSignoff = async (signoffRole, rule) => {
     const { error } = await signoff({
       scId: rule.scheduledChange.sc_id,
@@ -455,7 +454,7 @@ function ListRules(props) {
     if (!error) {
       setRulesWithScheduledChanges(
         rulesWithScheduledChanges.map(r => {
-          if (r.rule_id !== rule.rule_id) {
+          if (!r.scheduledChange || r.scheduledChange.sc_id !== rule.scheduledChange.sc_id) {
             return r;
           }
 

--- a/src/views/Rules/ListRules/index.jsx
+++ b/src/views/Rules/ListRules/index.jsx
@@ -96,6 +96,7 @@ function ListRules(props) {
       : ALL
   );
   const [dialogState, setDialogState] = useState(DIALOG_ACTION_INITIAL_STATE);
+  const [dialogMode, setDialogMode] = useState('delete');
   const [scheduleDeleteDate, setScheduleDeleteDate] = useState(
     addSeconds(new Date(), -30)
   );
@@ -399,6 +400,7 @@ function ListRules(props) {
     );
   };
 
+  // TODO: this changes the state for all pending inserts at the same time
   const doSignoff = async (signoffRole, rule) => {
     const { error } = await signoff({
       scId: rule.scheduledChange.sc_id,
@@ -431,13 +433,13 @@ function ListRules(props) {
         updateSignoffs(result);
       }
     } else {
+      setDialogMode('signoff');
       setDialogState({
         ...dialogState,
         open: true,
         title: 'Signoff as…',
         confirmText: 'Sign off',
         item: rule,
-        body: signoffDialogBody,
         handleComplete: handleSignoffDialogComplete,
         handleSubmit: handleSignoffDialogSubmit,
       });
@@ -467,9 +469,8 @@ function ListRules(props) {
     }
   };
 
-  const handleRuleDelete = rule => {
     const deleteDialogBody =
-      Object.keys(rule.required_signoffs).length > 0 ? (
+      dialogState.item && (Object.keys(dialogState.item.required_signoffs).length > 0 ? (
         <DateTimePicker
           disablePast
           inputVariant="outlined"
@@ -484,9 +485,11 @@ function ListRules(props) {
           value={scheduleDeleteDate}
         />
       ) : (
-        `This will delete rule ${rule.rule_id}.`
-      );
+        `This will delete rule ${dialogState.item.rule_id}.`
+      ));
 
+  const handleRuleDelete = rule => {
+      setDialogMode('delete');
     setDialogState({
       ...dialogState,
       open: true,
@@ -494,7 +497,6 @@ function ListRules(props) {
       confirmText: 'Delete',
       destructive: true,
       item: rule,
-      body: deleteDialogBody,
       handleComplete: handleDeleteDialogComplete,
       handleSubmit: handleDeleteDialogSubmit,
     });
@@ -702,7 +704,7 @@ function ListRules(props) {
         open={dialogState.open}
         title={dialogState.title}
         destructive={dialogState.destructive}
-        body={dialogState.body}
+        body={dialogMode === 'delete' ? deleteDialogBody : signoffDialogBody}
         confirmText={dialogState.confirmText}
         onSubmit={() => dialogState.handleSubmit(dialogState)}
         onError={handleDialogError}

--- a/src/views/Rules/ListRules/index.jsx
+++ b/src/views/Rules/ListRules/index.jsx
@@ -258,16 +258,18 @@ function ListRules(props) {
   }, []);
 
   useEffect(() => {
-    fetchRoles(username).then(userInfo => {
-      const roleList =
-        (userInfo.data && Object.keys(userInfo.data.data.roles)) || [];
+    if (username !== '') {
+      fetchRoles(username).then(userInfo => {
+        const roleList =
+          (userInfo.data && Object.keys(userInfo.data.data.roles)) || [];
 
-      setRoles(roleList);
+        setRoles(roleList);
 
-      if (roleList.length > 0) {
-        setSignoffRole(roleList[0]);
-      }
-    });
+        if (roleList.length > 0) {
+          setSignoffRole(roleList[0]);
+        }
+      });
+    }
   }, [username]);
 
   const filteredRulesWithScheduledChanges = useMemo(

--- a/src/views/Rules/ListRules/index.jsx
+++ b/src/views/Rules/ListRules/index.jsx
@@ -270,7 +270,7 @@ function ListRules(props) {
       if (roleList.length > 0) {
         setSignoffRole(roleList[0]);
       }
-    })
+    });
   }, [username]);
 
   const filteredRulesWithScheduledChanges = useMemo(
@@ -387,7 +387,10 @@ function ListRules(props) {
   const updateSignoffs = ({ signoffRole, rule }) => {
     setRulesWithScheduledChanges(
       rulesWithScheduledChanges.map(r => {
-        if (!r.scheduledChange || r.scheduledChange.sc_id !== rule.scheduledChange.sc_id) {
+        if (
+          !r.scheduledChange ||
+          r.scheduledChange.sc_id !== rule.scheduledChange.sc_id
+        ) {
           return r;
         }
 
@@ -454,7 +457,10 @@ function ListRules(props) {
     if (!error) {
       setRulesWithScheduledChanges(
         rulesWithScheduledChanges.map(r => {
-          if (!r.scheduledChange || r.scheduledChange.sc_id !== rule.scheduledChange.sc_id) {
+          if (
+            !r.scheduledChange ||
+            r.scheduledChange.sc_id !== rule.scheduledChange.sc_id
+          ) {
             return r;
           }
 
@@ -468,27 +474,27 @@ function ListRules(props) {
     }
   };
 
-    const deleteDialogBody =
-      dialogState.item && (Object.keys(dialogState.item.required_signoffs).length > 0 ? (
-        <DateTimePicker
-          disablePast
-          inputVariant="outlined"
-          fullWidth
-          label="When"
-          onError={handleDateTimePickerError}
-          helperText={
-            dateTimePickerError ||
-            (scheduleDeleteDate < new Date() ? 'Scheduled for ASAP' : undefined)
-          }
-          onDateTimeChange={handleDateTimeChange}
-          value={scheduleDeleteDate}
-        />
-      ) : (
-        `This will delete rule ${dialogState.item.rule_id}.`
-      ));
-
+  const deleteDialogBody =
+    dialogState.item &&
+    (Object.keys(dialogState.item.required_signoffs).length > 0 ? (
+      <DateTimePicker
+        disablePast
+        inputVariant="outlined"
+        fullWidth
+        label="When"
+        onError={handleDateTimePickerError}
+        helperText={
+          dateTimePickerError ||
+          (scheduleDeleteDate < new Date() ? 'Scheduled for ASAP' : undefined)
+        }
+        onDateTimeChange={handleDateTimeChange}
+        value={scheduleDeleteDate}
+      />
+    ) : (
+      `This will delete rule ${dialogState.item.rule_id}.`
+    ));
   const handleRuleDelete = rule => {
-      setDialogMode('delete');
+    setDialogMode('delete');
     setDialogState({
       ...dialogState,
       open: true,
@@ -622,7 +628,7 @@ function ListRules(props) {
           className={classes.ruleCard}
           key={rule.rule_id}
           rule={rule}
-          readOnly={username === '' ? true : false}
+          readOnly={username === ''}
           onRuleDelete={handleRuleDelete}
           onSignoff={() => handleSignoff(rule)}
           onRevoke={() => handleRevoke(rule)}

--- a/src/views/Rules/ListRules/index.jsx
+++ b/src/views/Rules/ListRules/index.jsx
@@ -213,10 +213,10 @@ function ListRules(props) {
           );
         }
 
-        returnedRule.requiredSignoffs = {};
+        returnedRule.required_signoffs = {};
         requiredSignoffs.forEach(rs => {
           if (ruleMatchesRequiredSignoff(rule, rs)) {
-            returnedRule.requiredSignoffs[rs.role] = rs.signoffs_required;
+            returnedRule.required_signoffs[rs.role] = rs.signoffs_required;
           }
         });
 
@@ -227,7 +227,7 @@ function ListRules(props) {
         if (sc.change_type === 'insert') {
           const rule = { scheduledChange: sc };
 
-          Object.assign(rule, { scheduledChange: sc });
+          Object.assign(rule, { scheduledChange: sc, required_signoffs: sc.required_signoffs });
           Object.assign(rule.scheduledChange, {
             when: new Date(rule.scheduledChange.when),
           });
@@ -353,7 +353,7 @@ function ListRules(props) {
       throw error;
     }
 
-    if (Object.keys(dialogRule.requiredSignoffs).length > 0) {
+    if (Object.keys(dialogRule.required_signoffs).length > 0) {
       return (await getScheduledChangeByRuleId(dialogRule.rule_id)).data
         .scheduled_changes[0];
     }
@@ -361,25 +361,6 @@ function ListRules(props) {
     return dialogRule.rule_id;
   };
 
-  const deleteDialogBody =
-    dialogState.item &&
-    (Object.keys(dialogState.item.requiredSignoffs).length > 0 ? (
-      <DateTimePicker
-        disablePast
-        inputVariant="outlined"
-        fullWidth
-        label="When"
-        onError={handleDateTimePickerError}
-        helperText={
-          dateTimePickerError ||
-          (scheduleDeleteDate < new Date() ? 'Scheduled for ASAP' : undefined)
-        }
-        onDateTimeChange={handleDateTimeChange}
-        value={scheduleDeleteDate}
-      />
-    ) : (
-      `This will delete rule ${dialogState.item.rule_id}.`
-    ));
   const signoffDialogBody = (
     <FormControl component="fieldset">
       <RadioGroup
@@ -479,6 +460,25 @@ function ListRules(props) {
   };
 
   const handleRuleDelete = rule => {
+    const deleteDialogBody =
+      Object.keys(rule.required_signoffs).length > 0 ? (
+        <DateTimePicker
+          disablePast
+          inputVariant="outlined"
+          fullWidth
+          label="When"
+          onError={handleDateTimePickerError}
+          helperText={
+            dateTimePickerError ||
+            (scheduleDeleteDate < new Date() ? 'Scheduled for ASAP' : undefined)
+          }
+          onDateTimeChange={handleDateTimeChange}
+          value={scheduleDeleteDate}
+        />
+      ) : (
+        `This will delete rule ${rule.rule_id}.`
+      );
+
     setDialogState({
       ...dialogState,
       open: true,

--- a/src/views/Rules/ListRules/index.jsx
+++ b/src/views/Rules/ListRules/index.jsx
@@ -616,6 +616,7 @@ function ListRules(props) {
           className={classes.ruleCard}
           key={rule.rule_id}
           rule={rule}
+          readOnly={username === '' ? true : false}
           onRuleDelete={handleRuleDelete}
           onSignoff={() => handleSignoff(rule)}
           onRevoke={() => handleRevoke(rule)}

--- a/src/views/Rules/ListRules/index.jsx
+++ b/src/views/Rules/ListRules/index.jsx
@@ -189,16 +189,13 @@ function ListRules(props) {
       fetchScheduledChanges(),
       fetchRules(),
       fetchRequiredSignoffs(OBJECT_NAMES.PRODUCT_REQUIRED_SIGNOFF),
-      fetchRoles(username),
       fetchProducts(),
       fetchChannels(),
-    ]).then(([sc, r, rs, userInfo]) => {
+    ]).then(([sc, r, rs]) => {
       if (!sc.data || !r.data || !rs.data) {
         return;
       }
 
-      const roleList =
-        (userInfo.data && Object.keys(userInfo.data.data.roles)) || [];
       const scheduledChanges = sc.data.data.scheduled_changes;
       const requiredSignoffs = rs.data.data.required_signoffs;
       const { rules } = r.data.data;
@@ -259,14 +256,22 @@ function ListRules(props) {
       });
 
       setRulesWithScheduledChanges(sortedRules);
+    });
+  }, []);
+
+  useEffect(() => {
+    fetchRoles(username).then(userInfo => {
+      const roleList =
+        (userInfo.data && Object.keys(userInfo.data.data.roles)) || [];
 
       setRoles(roleList);
 
       if (roleList.length > 0) {
         setSignoffRole(roleList[0]);
       }
-    });
-  }, []);
+    })
+  }, [username]);
+
   const filteredRulesWithScheduledChanges = useMemo(
     () =>
       productChannelFilter === ALL

--- a/src/views/Rules/ListRules/index.jsx
+++ b/src/views/Rules/ListRules/index.jsx
@@ -119,15 +119,12 @@ function ListRules(props) {
     revokeSignoff({ type: 'rules', ...props })
   );
   const [rolesAction, fetchRoles] = useAction(getUserInfo);
-  const isLoading =
-    products.loading ||
-    channels.loading ||
-    rules.loading ||
-    rolesAction.loading;
+  const isLoading = products.loading || channels.loading || rules.loading;
   const error =
     products.error ||
     channels.error ||
     rules.error ||
+    rolesAction.error ||
     scheduledChanges.error ||
     revokeAction.error ||
     (roles.length === 1 && signoffAction.error);
@@ -628,7 +625,6 @@ function ListRules(props) {
           className={classes.ruleCard}
           key={rule.rule_id}
           rule={rule}
-          readOnly={username === ''}
           onRuleDelete={handleRuleDelete}
           onSignoff={() => handleSignoff(rule)}
           onRevoke={() => handleRevoke(rule)}

--- a/src/views/Rules/ListRules/index.jsx
+++ b/src/views/Rules/ListRules/index.jsx
@@ -258,7 +258,7 @@ function ListRules(props) {
   }, []);
 
   useEffect(() => {
-    if (username !== '') {
+    if (username) {
       fetchRoles(username).then(userInfo => {
         const roleList =
           (userInfo.data && Object.keys(userInfo.data.data.roles)) || [];
@@ -314,6 +314,10 @@ function ListRules(props) {
   };
 
   const handleDialogClose = () => {
+    setDialogState({ ...dialogState, open: false });
+  };
+
+  const handleDialogExited = () => {
     setDialogState(DIALOG_ACTION_INITIAL_STATE);
   };
 
@@ -717,6 +721,7 @@ function ListRules(props) {
         error={dialogState.error}
         onComplete={dialogState.handleComplete}
         onClose={handleDialogClose}
+        onExited={handleDialogExited}
       />
       <Snackbar onClose={handleSnackbarClose} {...snackbarState} />
     </Dashboard>

--- a/src/views/Rules/ListRules/index.jsx
+++ b/src/views/Rules/ListRules/index.jsx
@@ -227,7 +227,10 @@ function ListRules(props) {
         if (sc.change_type === 'insert') {
           const rule = { scheduledChange: sc };
 
-          Object.assign(rule, { scheduledChange: sc, required_signoffs: sc.required_signoffs });
+          Object.assign(rule, {
+            scheduledChange: sc,
+            required_signoffs: sc.required_signoffs,
+          });
           Object.assign(rule.scheduledChange, {
             when: new Date(rule.scheduledChange.when),
           });


### PR DESCRIPTION
This is pretty much copy paste from #100, except for:
* I realized that the wrappers for making signoff/revoke requests were already generic enough to handle other objects, so I moved them to a better location.
* The dialog handling code is a bit more complicated because we're re-using the existing dialog from the view, like we did on the Releases view.

And it's built on top of #101.