### PR TITLE
Make items in settings menu clickable everywhere

### DIFF
--- a/src/components/Dashboard/SettingsMenu.jsx
+++ b/src/components/Dashboard/SettingsMenu.jsx
@@ -59,7 +59,7 @@ function SettingsMenu({ user, disabled }) {
         anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
         onClose={handleMenuClose}>
         {menuItems.settings.map(navItem => (
-          <MenuItem key={navItem.value} title={navItem.value}>
+          <MenuItem dense key={navItem.value} title={navItem.value}>
             <Link className={classes.link} to={navItem.path}>
               {upperCase(navItem.value)}
             </Link>


### PR DESCRIPTION
I noticed that clicking on the menu items of the setting button doesn't always work. For example, clicking on the edge of the menu item does nothing when I expect it to navigate to the link. This PR fixes the issue.