### PR TITLE
Skeleton UI for scheduled user permission changes (fixes #90)

### DIFF
--- a/src/components/RuleCard/index.jsx
+++ b/src/components/RuleCard/index.jsx
@@ -118,6 +118,7 @@ const useStyles = makeStyles(theme => ({
     overflowY: 'auto',
   },
   propertyWithScheduledChange: {
+    ...theme.mixins.redDot,
     width: theme.spacing(1),
     height: theme.spacing(1),
     borderRadius: '50%',

--- a/src/components/RuleCard/index.jsx
+++ b/src/components/RuleCard/index.jsx
@@ -119,11 +119,6 @@ const useStyles = makeStyles(theme => ({
   },
   propertyWithScheduledChange: {
     ...theme.mixins.redDot,
-    width: theme.spacing(1),
-    height: theme.spacing(1),
-    borderRadius: '50%',
-    background: 'red',
-    marginLeft: theme.spacing(1),
   },
   priorityScheduledChange: {
     marginLeft: -10,

--- a/src/components/SignoffCardEntry/index.jsx
+++ b/src/components/SignoffCardEntry/index.jsx
@@ -16,6 +16,7 @@ import { withUser } from '../../utils/AuthContext';
 const useStyles = makeStyles(theme => ({
   diff: {
     display: 'flex',
+    alignItems: 'center',
   },
   cardActions: {
     justifyContent: 'flex-end',
@@ -67,14 +68,18 @@ function SignoffCardEntry(props) {
         <Grid container spacing={4}>
           <Grid item xs={12} sm={4} className={classes.firstColumn}>
             <div className={classes.diff}>
-              <Typography>
-                {signoffsRequiredCurrent} member
-                {signoffsRequiredCurrent > 1 ? 's' : ''} of {name}
+              <Typography variant="body2">
+                <em>
+                  {signoffsRequiredCurrent} member
+                  {signoffsRequiredCurrent > 1 ? 's' : ''} of {name}
+                </em>
               </Typography>
               {isScheduled && (
                 <Fragment>
                   <ArrowRightIcon className={classes.arrowIcon} />
-                  <Typography>{signoffsRequiredIntent}</Typography>
+                  <Typography variant="body2">
+                    <em>{signoffsRequiredIntent}</em>
+                  </Typography>
                 </Fragment>
               )}
             </div>

--- a/src/components/SignoffSummary/index.jsx
+++ b/src/components/SignoffSummary/index.jsx
@@ -1,0 +1,110 @@
+import React from 'react';
+import { object, string } from 'prop-types';
+import classNames from 'classnames';
+import { makeStyles } from '@material-ui/styles';
+import List from '@material-ui/core/List';
+import ListItem from '@material-ui/core/ListItem';
+import ListItemText from '@material-ui/core/ListItemText';
+import ListSubheader from '@material-ui/core/ListSubheader';
+import Typography from '@material-ui/core/Typography';
+
+const useStyles = makeStyles(theme => ({
+  listSubheader: {
+    lineHeight: 1.5,
+    marginBottom: theme.spacing(0.5),
+    paddingLeft: theme.spacing(1),
+  },
+  listWrapper: {
+    display: 'flex',
+  },
+  listItemText: {
+    marginBottom: 0,
+    marginTop: 0,
+  },
+  signoffsList: {
+    marginRight: theme.spacing(6),
+    paddingTop: 0,
+    paddingBottom: 0,
+  },
+  signedBy: {
+    display: 'flex',
+    alignItems: 'center',
+  },
+}));
+
+function SignoffSummary(props) {
+  const classes = useStyles();
+  const { requiredSignoffs, signoffs, className } = props;
+  const listOfSignoffs = Object.entries(signoffs);
+
+  return (
+    <div className={classNames(classes.listWrapper, className)}>
+      <List
+        dense
+        subheader={
+          <ListSubheader className={classes.listSubheader}>
+            Requires Signoffs From
+          </ListSubheader>
+        }>
+        {Object.entries(requiredSignoffs).map(([role, count], index) => {
+          const key = `${role}-${index}`;
+
+          return (
+            <ListItem key={key} className={classes.signoffsList}>
+              <ListItemText
+                primary={`${count} member${count > 1 ? 's' : ''} of ${role}`}
+                className={classes.listItemText}
+              />
+            </ListItem>
+          );
+        })}
+      </List>
+      {listOfSignoffs && Boolean(listOfSignoffs.length) && (
+        <List
+          dense
+          subheader={
+            <ListSubheader className={classes.listSubheader}>
+              Signed By
+            </ListSubheader>
+          }>
+          <ListItem className={classes.signoffsList}>
+            {listOfSignoffs.map(([username, signoffRole]) => (
+              <ListItemText
+                key={username}
+                disableTypography
+                primary={
+                  <Typography
+                    component="p"
+                    className={classes.signedBy}
+                    variant="body2">
+                    {username}
+                    &nbsp; - &nbsp;
+                    <Typography
+                      component="span"
+                      color="textSecondary"
+                      variant="caption">
+                      {signoffRole}
+                    </Typography>
+                  </Typography>
+                }
+                className={classes.listItemText}
+              />
+            ))}
+          </ListItem>
+        </List>
+      )}
+    </div>
+  );
+}
+
+SignoffSummary.propTypes = {
+  requiredSignoffs: object.isRequired,
+  signoffs: object.isRequired,
+  className: string,
+};
+
+SignoffSummary.defaultProps = {
+  className: null,
+};
+
+export default SignoffSummary;

--- a/src/components/UserCard/index.jsx
+++ b/src/components/UserCard/index.jsx
@@ -100,41 +100,45 @@ function User(props) {
           />
         </CardActionArea>
       </Link>
-      <CardContent>
-        <List>
-          {Object.entries(permissions).map(([permission, details]) => (
-            <ListItem key={permission}>
-              <ListItemIcon>
-                <KeyVariantIcon />
-              </ListItemIcon>
-              <ListItemText
-                primary={
-                  <Fragment>
-                    {getPermissionString(
-                      permission,
-                      returnOptionIfExists(details.options, 'actions', []),
-                      returnOptionIfExists(details.options, 'products', [])
-                    )}
-                    {scheduledPermissions[permission] && (
-                      <span className={classes.propertyWithScheduledChange} />
-                    )}
-                  </Fragment>
-                }
-              />
-            </ListItem>
-          ))}
-          {Object.keys(roles).length > 0 && (
-            <ListItem>
-              <ListItemIcon>
-                <AccountGroupIcon />
-              </ListItemIcon>
-              <ListItemText>
-                holds the {getRolesString(Object.keys(roles))}
-              </ListItemText>
-            </ListItem>
-          )}
-        </List>
-      </CardContent>
+      {/* We don't need to check roles here because users without permissions
+            cannot hold roles */}
+      {Object.keys(permissions).length > 0 && (
+        <CardContent>
+          <List>
+            {Object.entries(permissions).map(([permission, details]) => (
+              <ListItem key={permission}>
+                <ListItemIcon>
+                  <KeyVariantIcon />
+                </ListItemIcon>
+                <ListItemText
+                  primary={
+                    <Fragment>
+                      {getPermissionString(
+                        permission,
+                        returnOptionIfExists(details.options, 'actions', []),
+                        returnOptionIfExists(details.options, 'products', [])
+                      )}
+                      {scheduledPermissions[permission] && (
+                        <span className={classes.propertyWithScheduledChange} />
+                      )}
+                    </Fragment>
+                  }
+                />
+              </ListItem>
+            ))}
+            {Object.keys(roles).length > 0 && (
+              <ListItem>
+                <ListItemIcon>
+                  <AccountGroupIcon />
+                </ListItemIcon>
+                <ListItemText>
+                  holds the {getRolesString(Object.keys(roles))}
+                </ListItemText>
+              </ListItem>
+            )}
+          </List>
+        </CardContent>
+      )}
       {Object.keys(scheduledPermissions).length > 0 &&
         Object.entries(scheduledPermissions).map(([permission, details]) => (
           <Fragment key={permission}>
@@ -175,7 +179,7 @@ function User(props) {
               </List>
               <Grid container spacing={4}>
                 <Grid item xs={4}>
-                  <div className={classes.statusLabel}>
+                  <div>
                     <StatusLabel state={getStatus(details.change_type)} />
                   </div>
                 </Grid>

--- a/src/components/UserCard/index.jsx
+++ b/src/components/UserCard/index.jsx
@@ -63,11 +63,7 @@ const useStyles = makeStyles(theme => ({
     marginBottom: theme.spacing(2),
   },
   propertyWithScheduledChange: {
-    width: theme.spacing(1),
-    height: theme.spacing(1),
-    borderRadius: '50%',
-    background: 'red',
-    marginLeft: theme.spacing(1),
+    ...theme.mixins.redDot,
     display: 'inline-block',
   },
 }));

--- a/src/components/UserCard/index.jsx
+++ b/src/components/UserCard/index.jsx
@@ -8,7 +8,7 @@ import CardActionArea from '@material-ui/core/CardActionArea';
 import CardActions from '@material-ui/core/CardActions';
 import CardContent from '@material-ui/core/CardContent';
 import Divider from '@material-ui/core/Divider';
-import Grid from '@material-ui/core/Grid';
+import Typography from '@material-ui/core/Typography';
 import AccountGroupIcon from 'mdi-react/AccountGroupIcon';
 import ArrowRightIcon from 'mdi-react/ArrowRightIcon';
 import KeyVariantIcon from 'mdi-react/KeyVariantIcon';
@@ -45,26 +45,27 @@ const useStyles = makeStyles(theme => ({
     ...theme.mixins.link,
   },
   scheduledChangeContainer: {
-    marginBottom: theme.spacing(4),
-  },
-  scheduledChangeDescriptionMarginLeft: {
-    lineHeight: '24px',
-    marginLeft: theme.spacing(1),
-  },
-  scheduledChangeDescription: {
-    lineHeight: '24px',
-  },
-  arrowContainer: {
     display: 'flex',
-    justifyContent: 'center',
+    marginBottom: theme.spacing(1),
+    textAlign: 'justify',
+    alignItems: 'center',
   },
-  statusLabel: {
-    marginLeft: theme.spacing(1),
-    marginBottom: theme.spacing(2),
+  statusLabelDiv: {
+    marginTop: theme.spacing(1),
+    marginBottom: theme.spacing(4),
   },
   propertyWithScheduledChange: {
     ...theme.mixins.redDot,
     display: 'inline-block',
+  },
+  arrowRightIcon: {
+    margin: `0 ${theme.spacing(1)}px`,
+  },
+  permissionText: {
+    wordBreak: 'break-all',
+  },
+  signoffSummary: {
+    marginLeft: -8,
   },
 }));
 
@@ -115,9 +116,9 @@ function User(props) {
             cannot hold roles */}
       {Object.keys(permissions).length > 0 && (
         <CardContent>
-          <List>
+          <List dense>
             {Object.entries(permissions).map(([permission, details]) => (
-              <ListItem key={permission}>
+              <ListItem key={permission} disableGutters>
                 <ListItemIcon>
                   <KeyVariantIcon />
                 </ListItemIcon>
@@ -138,7 +139,7 @@ function User(props) {
               </ListItem>
             ))}
             {Object.keys(roles).length > 0 && (
-              <ListItem>
+              <ListItem disableGutters>
                 <ListItemIcon>
                   <AccountGroupIcon />
                 </ListItemIcon>
@@ -155,58 +156,47 @@ function User(props) {
           <Fragment key={permission}>
             {Object.keys(permissions).length > 0 && <Divider />}
             <CardContent className={classes.scheduled}>
-              <div>
-                <StatusLabel
-                  className={classes.statusLabel}
-                  state={getStatus(details.change_type)}
-                />
-              </div>
-              <Grid container className={classes.scheduledChangeContainer}>
+              <div className={classes.scheduledChangeContainer}>
                 {permissions[permission] && (
                   <Fragment>
-                    <Grid
-                      item
-                      xs={5}
-                      className={classes.scheduledChangeDescriptionMarginLeft}>
-                      {getPermissionString(
-                        permission,
-                        returnOptionIfExists(
-                          permissions[permission].options,
-                          'actions',
-                          []
-                        ),
-                        returnOptionIfExists(
-                          permissions[permission].options,
-                          'products',
-                          []
-                        )
-                      )}
-                    </Grid>
-                    <Grid item xs={1} className={classes.arrowContainer}>
-                      <ArrowRightIcon />
-                    </Grid>
+                    <Typography
+                      variant="body2"
+                      className={classes.permissionText}>
+                      <em>
+                        {getPermissionString(
+                          permission,
+                          returnOptionIfExists(
+                            permissions[permission].options,
+                            'actions',
+                            []
+                          ),
+                          returnOptionIfExists(
+                            permissions[permission].options,
+                            'products',
+                            []
+                          )
+                        )}
+                      </em>
+                    </Typography>
+                    <ArrowRightIcon className={classes.arrowRightIcon} />
                   </Fragment>
                 )}
-                {/* If the permission already exists, the Grid elements above
-                      will be displayed, so we can only take up half of the
-                      Grid here. */}
-                <Grid
-                  item
-                  xs={permissions[permission] ? 5 : 12}
-                  className={
-                    permissions[permission]
-                      ? classes.scheduledChangeDescription
-                      : classes.scheduledChangeDescriptionMarginLeft
-                  }>
-                  {getPermissionString(
-                    permission,
-                    returnOptionIfExists(details.options, 'actions', []),
-                    returnOptionIfExists(details.options, 'products', []),
-                    details.change_type
-                  )}
-                </Grid>
-              </Grid>
+                <Typography variant="body2" className={classes.permissionText}>
+                  <em>
+                    {getPermissionString(
+                      permission,
+                      returnOptionIfExists(details.options, 'actions', []),
+                      returnOptionIfExists(details.options, 'products', []),
+                      details.change_type
+                    )}
+                  </em>
+                </Typography>
+              </div>
+              <div className={classes.statusLabelDiv}>
+                <StatusLabel state={getStatus(details.change_type)} />
+              </div>
               <SignoffSummary
+                className={classes.signoffSummary}
                 requiredSignoffs={details.required_signoffs}
                 signoffs={details.signoffs}
               />

--- a/src/components/UserCard/index.jsx
+++ b/src/components/UserCard/index.jsx
@@ -44,8 +44,18 @@ const useStyles = makeStyles(theme => ({
   link: {
     ...theme.mixins.link,
   },
-  arrowIcon: {
-    margin: `0 ${theme.spacing(1)}px`,
+  scheduledChangeDescriptionMarginLeft: {
+    lineHeight: '24px',
+    marginLeft: theme.spacing(1),
+    marginBottom: theme.spacing(2),
+  },
+  scheduledChangeDescription: {
+    lineHeight: '24px',
+    marginBottom: theme.spacing(2),
+  },
+  statusLabel: {
+    marginLeft: theme.spacing(1),
+    marginBottom: theme.spacing(2),
   },
   propertyWithScheduledChange: {
     width: theme.spacing(1),
@@ -64,7 +74,7 @@ function getStatus(changeType) {
     case 'delete':
       return LABELS.PENDING_DELETE;
     default:
-      return LABELS.PENDING;
+      return LABELS.PENDING_UPDATE;
   }
 }
 
@@ -142,54 +152,67 @@ function User(props) {
       {Object.keys(scheduledPermissions).length > 0 &&
         Object.entries(scheduledPermissions).map(([permission, details]) => (
           <Fragment key={permission}>
-            <Divider />
+            {Object.keys(permissions).length > 0 && <Divider />}
             <CardContent className={classes.scheduled}>
-              <List>
-                <ListItem>
-                  <ListItemIcon>
-                    <KeyVariantIcon />
-                  </ListItemIcon>
-                  <ListItemText>
-                    {permissions[permission] && (
+              <div>
+                <StatusLabel
+                  className={classes.statusLabel}
+                  state={getStatus(details.change_type)}
+                />
+              </div>
+              <Grid container>
+                {permissions[permission] && (
+                  <Fragment>
+                    <Grid
+                      item
+                      xs={5}
+                      className={classes.scheduledChangeDescriptionMarginLeft}>
+                      {getPermissionString(
+                        permission,
+                        returnOptionIfExists(
+                          permissions[permission].options,
+                          'actions',
+                          []
+                        ),
+                        returnOptionIfExists(
+                          permissions[permission].options,
+                          'products',
+                          []
+                        )
+                      )}
+                    </Grid>
+                    <Grid item xs={1}>
                       <Fragment>
-                        {getPermissionString(
-                          permission,
-                          returnOptionIfExists(
-                            permissions[permission].options,
-                            'actions',
-                            []
-                          ),
-                          returnOptionIfExists(
-                            permissions[permission].options,
-                            'products',
-                            []
-                          )
-                        )}
                         <ArrowRightIcon className={classes.arrowIcon} />
                       </Fragment>
-                    )}
-                    {getPermissionString(
-                      permission,
-                      returnOptionIfExists(details.options, 'actions', []),
-                      returnOptionIfExists(details.options, 'products', []),
-                      details.change_type
-                    )}
-                  </ListItemText>
-                </ListItem>
-              </List>
-              <Grid container spacing={4}>
-                <Grid item xs={4}>
-                  <div>
-                    <StatusLabel state={getStatus(details.change_type)} />
-                  </div>
-                </Grid>
-                <Grid item xs={8}>
-                  <SignoffSummary
-                    requiredSignoffs={details.required_signoffs}
-                    signoffs={details.signoffs}
-                  />
+                    </Grid>
+                  </Fragment>
+                )}
+                {/* If the permission already exists, the Grid elements above
+                      will be displayed, so we can only take up half of the
+                      Grid here.
+                      TODO: After adding marginLeft for alignment this started wrapping
+                      if xs=6 was set. */}
+                <Grid
+                  item
+                  xs={permissions[permission] ? 5 : 12}
+                  className={
+                    permissions[permission]
+                      ? classes.scheduledChangeDescription
+                      : classes.scheduledChangeDescriptionMarginLeft
+                  }>
+                  {getPermissionString(
+                    permission,
+                    returnOptionIfExists(details.options, 'actions', []),
+                    returnOptionIfExists(details.options, 'products', []),
+                    details.change_type
+                  )}
                 </Grid>
               </Grid>
+              <SignoffSummary
+                requiredSignoffs={details.required_signoffs}
+                signoffs={details.signoffs}
+              />
             </CardContent>
             <CardActions className={classes.cardActions}>
               {user && user.email in details.signoffs ? (

--- a/src/components/UserCard/index.jsx
+++ b/src/components/UserCard/index.jsx
@@ -44,14 +44,19 @@ const useStyles = makeStyles(theme => ({
   link: {
     ...theme.mixins.link,
   },
+  scheduledChangeContainer: {
+    marginBottom: theme.spacing(4),
+  },
   scheduledChangeDescriptionMarginLeft: {
     lineHeight: '24px',
     marginLeft: theme.spacing(1),
-    marginBottom: theme.spacing(2),
   },
   scheduledChangeDescription: {
     lineHeight: '24px',
-    marginBottom: theme.spacing(2),
+  },
+  arrowContainer: {
+    display: 'flex',
+    justifyContent: 'center',
   },
   statusLabel: {
     marginLeft: theme.spacing(1),
@@ -160,7 +165,7 @@ function User(props) {
                   state={getStatus(details.change_type)}
                 />
               </div>
-              <Grid container>
+              <Grid container className={classes.scheduledChangeContainer}>
                 {permissions[permission] && (
                   <Fragment>
                     <Grid
@@ -181,10 +186,8 @@ function User(props) {
                         )
                       )}
                     </Grid>
-                    <Grid item xs={1}>
-                      <Fragment>
-                        <ArrowRightIcon className={classes.arrowIcon} />
-                      </Fragment>
+                    <Grid item xs={1} className={classes.arrowContainer}>
+                      <ArrowRightIcon />
                     </Grid>
                   </Fragment>
                 )}

--- a/src/components/UserCard/index.jsx
+++ b/src/components/UserCard/index.jsx
@@ -58,12 +58,13 @@ const useStyles = makeStyles(theme => ({
 }));
 
 function getStatus(changeType) {
-  if (changeType !== 'delete') {
-    return LABELS.PENDING;
-  }
-
-  if (changeType === 'delete') {
-    return LABELS.PENDING_DELETE;
+  switch (changeType) {
+    case 'insert':
+      return LABELS.PENDING_INSERT;
+    case 'delete':
+      return LABELS.PENDING_DELETE;
+    default:
+      return LABELS.PENDING;
   }
 }
 

--- a/src/components/UserCard/index.jsx
+++ b/src/components/UserCard/index.jsx
@@ -189,9 +189,7 @@ function User(props) {
                 )}
                 {/* If the permission already exists, the Grid elements above
                       will be displayed, so we can only take up half of the
-                      Grid here.
-                      TODO: After adding marginLeft for alignment this started wrapping
-                      if xs=6 was set. */}
+                      Grid here. */}
                 <Grid
                   item
                   xs={permissions[permission] ? 5 : 12}

--- a/src/theme.js
+++ b/src/theme.js
@@ -40,6 +40,13 @@ export default createMuiTheme({
       overflow: 'hidden',
       textOverflow: 'ellipsis',
     },
+    redDot: {
+      width: SPACING.UNIT,
+      height: SPACING.UNIT,
+      borderRadius: '50%',
+      background: 'red',
+      marginLeft: SPACING.UNIT,
+    },
   },
   overrides: {
     MuiListItem: {

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -7,6 +7,7 @@ export const OBJECT_NAMES = {
 };
 export const LABELS = {
   PENDING: 'pending',
+  PENDING_INSERT: 'pendingInsert',
   PENDING_DELETE: 'pendingDelete',
 };
 export const RULE_DIFF_PROPERTIES = [

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -9,6 +9,7 @@ export const LABELS = {
   PENDING: 'pending',
   PENDING_INSERT: 'pendingInsert',
   PENDING_DELETE: 'pendingDelete',
+  PENDING_UPDATE: 'pendingUpdate',
 };
 export const RULE_DIFF_PROPERTIES = [
   'alias',

--- a/src/utils/labels.js
+++ b/src/utils/labels.js
@@ -1,6 +1,7 @@
 export default {
   pending: 'info',
   pendingDelete: 'error',
+  pendingInsert: 'success',
   delete: 'error',
   update: 'info',
 };

--- a/src/utils/labels.js
+++ b/src/utils/labels.js
@@ -2,6 +2,7 @@ export default {
   pending: 'info',
   pendingDelete: 'error',
   pendingInsert: 'success',
+  pendingUpdate: 'info',
   delete: 'error',
   update: 'info',
 };

--- a/src/utils/userUtils.js
+++ b/src/utils/userUtils.js
@@ -5,18 +5,27 @@ import { PERMISSION_RESTRICTION_MAPPINGS } from './constants';
 const formatListToLanguage = array =>
   array.concat(array.splice(-2, 2).join(' and ')).join(', ');
 const permissionStrings = (productStr, actionStr) => ({
-  admin: `is a full fledged administrator ${productStr}`,
-  emergency_shutoff: `is allowed to ${actionStr} on Emergency Shutoffs ${productStr}`,
-  release: `is allowed to ${actionStr} Releases ${productStr}`,
-  release_locale: `is allowed to ${actionStr} on locale sections of Releases ${productStr}`,
-  release_read_only: `is allowed to ${actionStr} the read only flag of Releases ${productStr}`,
-  rule: `is allowed to ${actionStr} on Rules ${productStr}`,
-  permission: `is allowed to ${actionStr} User Permissions`,
-  required_signoff: `is allowed to ${actionStr} on Required Signoff configuration ${productStr}`,
-  scheduled_change: `is allowed to ${actionStr} Scheduled Changes`,
+  admin: `a full fledged administrator ${productStr}`,
+  emergency_shutoff: `allowed to ${actionStr} Emergency Shutoffs ${productStr}`,
+  release: `allowed to ${actionStr} Releases ${productStr}`,
+  release_locale: `allowed to ${actionStr} locale sections of Releases ${productStr}`,
+  release_read_only: `allowed to ${actionStr} the read only flag of Releases ${productStr}`,
+  rule: `allowed to ${actionStr} Rules ${productStr}`,
+  permission: `allowed to ${actionStr} User Permissions`,
+  required_signoff: `allowed to ${actionStr} on Required Signoff configuration ${productStr}`,
+  scheduled_change: `allowed to ${actionStr} Scheduled Changes`,
 });
-const getPermissionString = (permission, actions, products) => {
-  let actionStr = 'perform any action';
+const getPermissionString = (
+  permission,
+  actions,
+  products,
+  scheduledChangeType = null
+) => {
+  const prefix =
+    (scheduledChangeType &&
+      (scheduledChangeType === 'delete' ? 'will no longer be' : 'will be')) ||
+    'is';
+  let actionStr = 'perform any action on';
   let productStr = 'for all products';
 
   if (actions.length > 0) {
@@ -29,7 +38,7 @@ const getPermissionString = (permission, actions, products) => {
     productStr = `for ${tmp}`;
   }
 
-  return permissionStrings(productStr, actionStr)[permission];
+  return `${prefix} ${permissionStrings(productStr, actionStr)[permission]}`;
 };
 
 const getRolesString = roles => {

--- a/src/views/Users/ListUsers/index.jsx
+++ b/src/views/Users/ListUsers/index.jsx
@@ -55,6 +55,7 @@ function ListUsers() {
               username={user}
               roles={users[user].roles}
               permissions={users[user].permissions}
+              scheduledPermissions={users[user].scheduledPermissions}
             />
           ))}
           <Tooltip title="Add User">

--- a/src/views/Users/ViewUser/index.jsx
+++ b/src/views/Users/ViewUser/index.jsx
@@ -133,7 +133,7 @@ function ViewUser({ isNewUser, ...props }) {
           name => {
             const details = userdata.data.data.permissions[name];
             const sc = scheduledChanges.data.data.scheduled_changes.filter(
-              sc => sc.permission === name
+              sc => sc.username === existingUsername && sc.permission === name
             );
             const permission = {
               name,
@@ -168,7 +168,7 @@ function ViewUser({ isNewUser, ...props }) {
         // Scheduled inserts don't have an existing permission to associate
         // with, so we need to create an empty one, and add to it.
         scheduledChanges.data.data.scheduled_changes.forEach(sc => {
-          if (sc.change_type === 'insert') {
+          if (sc.username === existingUsername && sc.change_type === 'insert') {
             const p = getEmptyPermission();
 
             p.name = sc.permission;

--- a/src/views/Users/utils/getUsersInfo.jsx
+++ b/src/views/Users/utils/getUsersInfo.jsx
@@ -1,16 +1,30 @@
-import { getUserInfo } from '../../../services/users';
+import { getUserInfo, getScheduledChanges } from '../../../services/users';
 
 export default async users => {
   const userInfo = {};
-  const result = await Promise.all(
+  const userData = await Promise.all(
     [].concat(users.map(user => getUserInfo(user)))
   );
+  const scData = await getScheduledChanges();
 
-  result.forEach(user => {
+  userData.forEach(user => {
     userInfo[user.data.username] = {
       roles: user.data.roles,
       permissions: user.data.permissions,
+      scheduledPermissions: {},
     };
+  });
+
+  scData.data.scheduled_changes.forEach(sc => {
+    if (!(sc.username in userInfo)) {
+      userInfo[sc.username] = {
+        roles: {},
+        permissions: {},
+        scheduledPermissions: {},
+      };
+    }
+
+    userInfo[sc.username].scheduledPermissions[sc.permission] = sc;
   });
 
   return userInfo;


### PR DESCRIPTION
I largely took inspiration from the Required Signoffs UI for this one, using the arrows to highlight changes instead of a diff viewer. The best idea I could come up with for showing these is one additional section per pending change. If there's many queued up this will obviously get rather lengthy, but permission scheduled changes are relatively rare and short lived, so this is unlikely to be the case.

There's a couple of rough edges that I'm not 100% happy with as well. They're not dealbreakers, but if you have any ideas I'd appreciate them:
* Pending inserts and pending updates look very similar at a glance. They both use the same `PENDING` badge; the only differences are the lack of red dot on the original permission, and the `->` in the pending change.
* On longer permission descriptions, the text for the scheduled change version wraps all the way back to the current permission, which I find a little confusing - it can look like it's the text from the current permission wrapping instead. I couldn't figure out how to fix this.

![image](https://user-images.githubusercontent.com/49649/62059548-851cc280-b1f1-11e9-8139-df516a184bcf.png)

This will need rebasing after #101 lands.