### PR TITLE
Fix spacing with card when change_type is delete

### DIFF
--- a/src/views/Rules/ListRules/index.jsx
+++ b/src/views/Rules/ListRules/index.jsx
@@ -426,13 +426,13 @@ function ListRules(props) {
           rule.scheduledChange
         );
 
-        if (rule.scheduledChange.change_type === 'update') {
-          // divider
-          height += theme.spacing(2) + 1;
-        }
-
         // diff viewer + marginTop
         height += diffedProperties.length * diffRowHeight + theme.spacing(1);
+      }
+
+      if (rule.scheduledChange.change_type === 'delete' || rule.scheduledChange.change_type === 'update') {
+        // divider
+        height += theme.spacing(2) + 1;
 
         if (Object.keys(rule.scheduledChange.required_signoffs).length > 0) {
           const requiredRoles = Object.keys(

--- a/src/views/Rules/ListRules/index.jsx
+++ b/src/views/Rules/ListRules/index.jsx
@@ -430,7 +430,10 @@ function ListRules(props) {
         height += diffedProperties.length * diffRowHeight + theme.spacing(1);
       }
 
-      if (rule.scheduledChange.change_type === 'delete' || rule.scheduledChange.change_type === 'update') {
+      if (
+        rule.scheduledChange.change_type === 'delete' ||
+        rule.scheduledChange.change_type === 'update'
+      ) {
         // divider
         height += theme.spacing(2) + 1;
 


### PR DESCRIPTION
http://localhost:9000/rules?product=Firefox#ruleId=69 was not showing properly (rule was overlapping with another card) then I realized that the "Requires Signoff" section height was not being calculated for a card with change_type delete.