### PR TITLE
Move CSS import to DiffRule

### DIFF
--- a/src/components/DiffRule/index.jsx
+++ b/src/components/DiffRule/index.jsx
@@ -2,6 +2,7 @@ import React, { useMemo } from 'react';
 import { makeStyles } from '@material-ui/styles';
 import { diffLines, formatLines } from 'unidiff';
 import { Diff, Hunk, parseDiff } from 'react-diff-view';
+import 'react-diff-view/style/index.css';
 import { rule } from '../../utils/prop-types';
 import getDiff from '../../utils/diff';
 import getDiffedProperties from '../../utils/getDiffedProperties';

--- a/src/components/RuleCard/index.jsx
+++ b/src/components/RuleCard/index.jsx
@@ -21,7 +21,6 @@ import UpdateIcon from 'mdi-react/UpdateIcon';
 import PlusCircleIcon from 'mdi-react/PlusCircleIcon';
 import HistoryIcon from 'mdi-react/HistoryIcon';
 import { formatDistanceStrict } from 'date-fns';
-import 'react-diff-view/style/index.css';
 import Button from '../Button';
 import DiffRule from '../DiffRule';
 import SignoffSummary from '../SignoffSummary';


### PR DESCRIPTION
Not sure why I didn't move this earlier but this will make sure other views will be able to use the diff viewer without having to load the rules view first.