### PR TITLE
Schedule rule deletes when signoffs are required (fixes #115)

### DIFF
--- a/src/components/VariableSizeList/index.jsx
+++ b/src/components/VariableSizeList/index.jsx
@@ -1,5 +1,9 @@
-import React, { useEffect, useRef, useImperativeHandle, forwardRef } from 'react';
-import { number } from 'prop-types';
+import React, {
+  useEffect,
+  useRef,
+  useImperativeHandle,
+  forwardRef,
+} from 'react';
 import { AutoSizer, WindowScroller, List } from 'react-virtualized';
 import { APP_BAR_HEIGHT } from '../../utils/constants';
 
@@ -14,7 +18,7 @@ function VariableSizeList(props, ref) {
   }, [scrollToRow]);
 
   useImperativeHandle(ref, () => ({
-    recomputeRowHeights: index => listRef.current.recomputeRowHeights(index)
+    recomputeRowHeights: index => listRef.current.recomputeRowHeights(index),
   }));
 
   return (
@@ -40,6 +44,6 @@ function VariableSizeList(props, ref) {
       )}
     </WindowScroller>
   );
-};
+}
 
 export default forwardRef(VariableSizeList);

--- a/src/components/VariableSizeList/index.jsx
+++ b/src/components/VariableSizeList/index.jsx
@@ -1,17 +1,21 @@
-import React, { useEffect, useRef } from 'react';
+import React, { useEffect, useRef, useImperativeHandle, forwardRef } from 'react';
 import { number } from 'prop-types';
 import { AutoSizer, WindowScroller, List } from 'react-virtualized';
 import { APP_BAR_HEIGHT } from '../../utils/constants';
 
-function VariableSizeList(props) {
+function VariableSizeList(props, ref) {
   const { scrollToRow, ...rest } = props;
-  const listRef = props.listRef ? props.listRef : useRef(null);
+  const listRef = useRef(null);
 
   useEffect(() => {
     const rowOffset = listRef.current.getOffsetForRow({ index: scrollToRow });
 
     listRef.current.scrollToPosition(rowOffset - APP_BAR_HEIGHT);
   }, [scrollToRow]);
+
+  useImperativeHandle(ref, () => ({
+    recomputeRowHeights: index => listRef.current.recomputeRowHeights(index)
+  }));
 
   return (
     <WindowScroller>
@@ -36,14 +40,6 @@ function VariableSizeList(props) {
       )}
     </WindowScroller>
   );
-}
-
-VariableSizeList.propTypes = {
-  scrollToRow: number,
 };
 
-VariableSizeList.defaultProps = {
-  scrollToRow: null,
-};
-
-export default VariableSizeList;
+export default forwardRef(VariableSizeList);

--- a/src/components/VariableSizeList/index.jsx
+++ b/src/components/VariableSizeList/index.jsx
@@ -4,10 +4,11 @@ import React, {
   useImperativeHandle,
   forwardRef,
 } from 'react';
+import { number } from 'prop-types';
 import { AutoSizer, WindowScroller, List } from 'react-virtualized';
 import { APP_BAR_HEIGHT } from '../../utils/constants';
 
-function VariableSizeList(props, ref) {
+const WrappedComponent = forwardRef((props, ref) => {
   const { scrollToRow, ...rest } = props;
   const listRef = useRef(null);
 
@@ -44,6 +45,16 @@ function VariableSizeList(props, ref) {
       )}
     </WindowScroller>
   );
-}
+});
 
-export default forwardRef(VariableSizeList);
+WrappedComponent.displayName = 'VariableSizeList';
+
+WrappedComponent.propTypes = {
+  scrollToRow: number,
+};
+
+WrappedComponent.defaultProps = {
+  scrollToRow: null,
+};
+
+export default WrappedComponent;

--- a/src/components/VariableSizeList/index.jsx
+++ b/src/components/VariableSizeList/index.jsx
@@ -5,7 +5,7 @@ import { APP_BAR_HEIGHT } from '../../utils/constants';
 
 function VariableSizeList(props) {
   const { scrollToRow, ...rest } = props;
-  const listRef = useRef(null);
+  const listRef = props.listRef ? props.listRef : useRef(null);
 
   useEffect(() => {
     const rowOffset = listRef.current.getOffsetForRow({ index: scrollToRow });

--- a/src/components/VariableSizeList/index.jsx
+++ b/src/components/VariableSizeList/index.jsx
@@ -8,7 +8,7 @@ import { number } from 'prop-types';
 import { AutoSizer, WindowScroller, List } from 'react-virtualized';
 import { APP_BAR_HEIGHT } from '../../utils/constants';
 
-const WrappedComponent = forwardRef((props, ref) => {
+const VariableSizeList = forwardRef((props, ref) => {
   const { scrollToRow, ...rest } = props;
   const listRef = useRef(null);
 
@@ -47,14 +47,14 @@ const WrappedComponent = forwardRef((props, ref) => {
   );
 });
 
-WrappedComponent.displayName = 'VariableSizeList';
+VariableSizeList.displayName = 'VariableSizeList';
 
-WrappedComponent.propTypes = {
+VariableSizeList.propTypes = {
   scrollToRow: number,
 };
 
-WrappedComponent.defaultProps = {
+VariableSizeList.defaultProps = {
   scrollToRow: null,
 };
 
-export default WrappedComponent;
+export default VariableSizeList;

--- a/src/views/Rules/ListRules/index.jsx
+++ b/src/views/Rules/ListRules/index.jsx
@@ -303,7 +303,6 @@ function ListRules(props) {
           }),
     [productChannelFilter, rulesWithScheduledChanges]
   );
-
   const handleDateTimePickerError = error => {
     setDateTimePickerError(error);
   };

--- a/src/views/Rules/ListRules/index.jsx
+++ b/src/views/Rules/ListRules/index.jsx
@@ -27,6 +27,7 @@ import {
   getRules,
   getScheduledChanges,
   getScheduledChangeByRuleId,
+  addScheduledChange,
   deleteRule,
 } from '../../../services/rules';
 import { getRequiredSignoffs } from '../../../services/requiredSignoffs';
@@ -112,6 +113,7 @@ function ListRules(props) {
   );
   const fetchRequiredSignoffs = useAction(getRequiredSignoffs)[1];
   const delRule = useAction(deleteRule)[1];
+  const scheduleDelRule = useAction(addScheduledChange)[1];
   const [signoffAction, signoff] = useAction(props =>
     makeSignoff({ type: 'rules', ...props })
   );
@@ -356,9 +358,16 @@ function ListRules(props) {
 
   const handleDeleteDialogSubmit = async state => {
     const dialogRule = state.item;
-    const { error } = await delRule({
+    const now = new Date();
+    const when = scheduleDeleteDate >= now ? scheduleDeleteDate.getTime() : now.getTime() + 5000;
+    const { error } = Object.keys(dialogRule.required_signoffs).length === 0 ? await delRule({
       ruleId: dialogRule.rule_id,
       dataVersion: dialogRule.data_version,
+    }) : await scheduleDelRule({
+      change_type: 'delete',
+      when,
+      rule_id: dialogRule.rule_id,
+      data_version: dialogRule.data_version,
     });
 
     if (error) {

--- a/src/views/Rules/ListRules/index.jsx
+++ b/src/views/Rules/ListRules/index.jsx
@@ -711,11 +711,11 @@ function ListRules(props) {
           {filteredRulesWithScheduledChanges && (
             <Fragment>
               <VariableSizeList
+                ref={ruleListRef}
                 rowRenderer={Row}
                 scrollToRow={scrollToRow}
                 rowHeight={getRowHeight}
                 rowCount={filteredRulesCount}
-                listRef={ruleListRef}
               />
             </Fragment>
           )}


### PR DESCRIPTION
This works, but needs an extra fix to make `rowHeight` get recalculated. I dug into that part a bit, and it turns out that the `List` we use has a `recomputeRowHeights` function to do just that. I tried to get that working with a `ref` (as suggested in https://github.com/bvaughn/react-virtualized/issues/545), but our architecture doesn't seem to allow it - I get an error about needing to use a `ForwardRef` instead, which I wasn't able to get working.

Before I dive deeper down that rabbit hole, is that the right way to go, or is there a better solution here?