### PR TITLE
Don't mutate user data when rendering it. (fixes #143)

### DIFF
--- a/src/utils/userUtils.js
+++ b/src/utils/userUtils.js
@@ -3,7 +3,7 @@ import { PERMISSION_RESTRICTION_MAPPINGS } from './constants';
 // TODO: use https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/ListFormat
 // when it's available in Firefox
 const formatListToLanguage = array =>
-  array.concat(array.splice(-2, 2).join(' and ')).join(', ');
+  [].concat(array.slice(null, -2), array.slice(-2).join(' and ')).join(', ');
 const permissionStrings = (productStr, actionStr) => ({
   admin: `a full fledged administrator ${productStr}`,
   emergency_shutoff: `allowed to ${actionStr} Emergency Shutoffs ${productStr}`,


### PR DESCRIPTION
Turns out this was caused by `splice`, which was modifying state. I had to tweak `formatListToLanguage` a bit to fix this.