### PR TITLE
Allow full deletes of Required Signoffs, and cancelling deletions

### DIFF
--- a/src/components/DialogAction/index.jsx
+++ b/src/components/DialogAction/index.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { oneOfType, object, node, string, func, bool } from 'prop-types';
 import { makeStyles } from '@material-ui/styles';
 import Dialog from '@material-ui/core/Dialog';
@@ -44,6 +44,12 @@ function DialogAction(props) {
     destructive,
     ...rest
   } = props;
+  let cancelled = false;
+
+  // Set this so we can avoid calling setActionExecuting if the caller
+  // decides to do something that unmounts us in onComplete.
+  useEffect(() => () => (cancelled = true));
+
   const handleSubmit = async () => {
     setActionExecuting(true);
 
@@ -63,7 +69,9 @@ function DialogAction(props) {
       onComplete(result);
     }
 
-    setActionExecuting(false);
+    if (!cancelled) {
+      setActionExecuting(false);
+    }
   };
 
   return (

--- a/src/components/DialogAction/index.jsx
+++ b/src/components/DialogAction/index.jsx
@@ -47,7 +47,7 @@ function DialogAction(props) {
   let cancelled = false;
 
   // Set this so we can avoid calling setActionExecuting if the caller
-  // decides to do something that unmounts us in onComplete.
+  // decides to do something that unmounts us in onComplete or onError.
   useEffect(() => () => (cancelled = true));
 
   const handleSubmit = async () => {
@@ -60,7 +60,9 @@ function DialogAction(props) {
         onError(error);
       }
 
-      setActionExecuting(false);
+      if (!cancelled) {
+        setActionExecuting(false);
+      }
 
       return;
     }

--- a/src/components/SignoffCardEntry/index.jsx
+++ b/src/components/SignoffCardEntry/index.jsx
@@ -55,7 +55,7 @@ function getStatus(entry) {
 
 function SignoffCardEntry(props) {
   const classes = useStyles();
-  const { user, entry, name, onSignoff, onRevoke } = props;
+  const { user, entry, name, onCancelDelete, onSignoff, onRevoke } = props;
   const status = getStatus(entry);
   const isScheduled = 'sc' in entry;
   const signoffsRequiredCurrent = Number(entry.signoffs_required);
@@ -102,7 +102,9 @@ function SignoffCardEntry(props) {
       {isScheduled && (
         <CardActions className={classes.cardActions}>
           {isScheduled && entry.sc.change_type === 'delete' && (
-            <Button color="secondary">Cancel Delete</Button>
+            <Button color="secondary" onClick={onCancelDelete}>
+              Cancel Delete
+            </Button>
           )}
           {user && user.email in entry.sc.signoffs ? (
             <Button color="secondary" onClick={onRevoke}>
@@ -121,6 +123,7 @@ function SignoffCardEntry(props) {
 
 SignoffCardEntry.propTypes = {
   entry: signoffEntry.isRequired,
+  onCancelDelete: func.isRequired,
   onSignoff: func.isRequired,
   onRevoke: func.isRequired,
 };

--- a/src/services/requiredSignoffs.js
+++ b/src/services/requiredSignoffs.js
@@ -14,7 +14,7 @@ const updateRequiredSignoff = params => {
   return axios.post(url, postData);
 };
 
-const deleteRequiredSignoff = params => {
+const deleteScheduledChange = params => {
   const { scId, type, ...data } = params;
   const url = `/scheduled_changes/required_signoffs/${type}/${scId}`;
 
@@ -28,5 +28,5 @@ export {
   getRequiredSignoffs,
   getScheduledChanges,
   updateRequiredSignoff,
-  deleteRequiredSignoff,
+  deleteScheduledChange,
 };

--- a/src/views/RequiredSignoffs/ListSignoffs/index.jsx
+++ b/src/views/RequiredSignoffs/ListSignoffs/index.jsx
@@ -20,6 +20,7 @@ import DialogAction from '../../../components/DialogAction';
 import SignoffCard from '../../../components/SignoffCard';
 import ErrorPanel from '../../../components/ErrorPanel';
 import SignoffCardEntry from '../../../components/SignoffCardEntry';
+import { deleteScheduledChange } from '../../../services/requiredSignoffs';
 import { makeSignoff, revokeSignoff } from '../../../services/signoffs';
 import { getUserInfo } from '../../../services/users';
 import Link from '../../../utils/Link';
@@ -69,12 +70,14 @@ function ListSignoffs({ user }) {
   const [signoffRole, setSignoffRole] = useState('');
   const [dialogState, setDialogState] = useState(DIALOG_ACTION_INITIAL_STATE);
   const [getRSAction, getRS] = useAction(getRequiredSignoffs);
+  const [deleteRSAction, delRS] = useAction(deleteScheduledChange);
   const [signoffAction, signoff] = useAction(makeSignoff);
   const [revokeAction, revoke] = useAction(revokeSignoff);
   const [rolesAction, getRoles] = useAction(getUserInfo);
   const loading = getRSAction.loading || rolesAction.loading;
   const error =
     getRSAction.error ||
+    deleteRSAction.error ||
     revokeAction.error ||
     rolesAction.error ||
     // If there's more than one role, this error is shown inside of the dialog
@@ -156,6 +159,32 @@ function ListSignoffs({ user }) {
       error,
       result: { signoffRole, type, roleName, product, channelName },
     };
+  };
+
+  const handleCancelDelete = async (
+    type,
+    entry,
+    roleName,
+    product,
+    channelName
+  ) => {
+    const { error } = await delRS({
+      type: channelName ? 'product' : 'permissions',
+      scId: entry.sc.sc_id,
+      data_version: entry.sc.sc_data_version,
+    });
+
+    if (!error) {
+      const result = clone(requiredSignoffs);
+
+      if (type === OBJECT_NAMES.PRODUCT_REQUIRED_SIGNOFF) {
+        delete result[product].channels[channelName][roleName].sc;
+      } else {
+        delete result[product].permissions[roleName].sc;
+      }
+
+      setRequiredSignoffs(result);
+    }
   };
 
   const handleSignoff = async (...props) => {
@@ -264,6 +293,14 @@ function ListSignoffs({ user }) {
                         key={name}
                         name={name}
                         entry={role}
+                        onCancelDelete={() =>
+                          handleCancelDelete(
+                            OBJECT_NAMES.PERMISSIONS_REQUIRED_SIGNOFF,
+                            role,
+                            name,
+                            product
+                          )
+                        }
                         onSignoff={() =>
                           handleSignoff(
                             OBJECT_NAMES.PERMISSIONS_REQUIRED_SIGNOFF,
@@ -321,6 +358,15 @@ function ListSignoffs({ user }) {
                                 key={roleName}
                                 name={roleName}
                                 entry={role}
+                                onCancelDelete={() =>
+                                  handleCancelDelete(
+                                    OBJECT_NAMES.PRODUCT_REQUIRED_SIGNOFF,
+                                    role,
+                                    roleName,
+                                    product,
+                                    channelName
+                                  )
+                                }
                                 onSignoff={() =>
                                   handleSignoff(
                                     OBJECT_NAMES.PRODUCT_REQUIRED_SIGNOFF,

--- a/src/views/RequiredSignoffs/ViewSignoff/index.jsx
+++ b/src/views/RequiredSignoffs/ViewSignoff/index.jsx
@@ -165,8 +165,23 @@ function ViewSignoff({ isNewSignoff, ...props }) {
     }
   };
 
-  // TODO: Add delete logic
-  const handleSignoffDelete = () => {};
+  const handleSignoffDelete = async () => {
+    const { error } = await saveRS({
+      product: productTextValue,
+      channel: channelTextValue,
+      // pass nothing for current and additional roles
+      // to make sure all existing roles are scheduled
+      // for deletion.
+      roles: [],
+      originalRoles,
+      additionalRoles: [],
+      isNewSignoff,
+    });
+
+    if (!error) {
+      props.history.push('/required-signoffs');
+    }
+  };
 
   useEffect(() => {
     if (isNewSignoff) {

--- a/src/views/RequiredSignoffs/ViewSignoff/index.jsx
+++ b/src/views/RequiredSignoffs/ViewSignoff/index.jsx
@@ -20,6 +20,7 @@ import ContentSaveIcon from 'mdi-react/ContentSaveIcon';
 import PlusIcon from 'mdi-react/PlusIcon';
 import DeleteIcon from 'mdi-react/DeleteIcon';
 import Dashboard from '../../../components/Dashboard';
+import DialogAction from '../../../components/DialogAction';
 import Button from '../../../components/Button';
 import SpeedDial from '../../../components/SpeedDial';
 import ErrorPanel from '../../../components/ErrorPanel';
@@ -30,6 +31,7 @@ import getRequiredSignoffs from '../utils/getRequiredSignoffs';
 import updateRequiredSignoffs from '../utils/updateRequiredSignoffs';
 import getRolesFromRequiredSignoffs from '../utils/getRolesFromRequiredSignoffs';
 import useAction from '../../../hooks/useAction';
+import { DIALOG_ACTION_INITIAL_STATE } from '../../../utils/constants';
 
 let additionalRoleId = 0;
 const useStyles = makeStyles(theme => ({
@@ -87,13 +89,24 @@ function ViewSignoff({ isNewSignoff, ...props }) {
   const [additionalRoles, setAdditionalRoles] = useState(
     isNewSignoff ? [getEmptyRole()] : []
   );
+  const [dialogState, setDialogState] = useState(DIALOG_ACTION_INITIAL_STATE);
   const [requiredSignoffs, getRS] = useAction(getRequiredSignoffs);
   const [products, fetchProducts] = useAction(getProducts);
   const [channels, fetchChannels] = useAction(getChannels);
   const [saveAction, saveRS] = useAction(updateRequiredSignoffs);
   const isLoading =
     requiredSignoffs.loading || products.loading || channels.loading;
-  const error = requiredSignoffs.error || products.error || saveAction.error;
+  const error =
+    requiredSignoffs.error ||
+    products.error ||
+    // Don't show this in the main error bar if the confirmation dialog was
+    // used. This has the side effect of the error moving from the dialog
+    // to the main error bar if the dialog is closed, which is arguably
+    // desirable?
+    (!dialogState.open && saveAction.error);
+  const dialogBody = channelTextValue
+    ? `This will delete all Required Signoffs for the ${productTextValue} ${channelTextValue} channel`
+    : `This will delete all Required Signoffs for ${productTextValue} permissions`;
   const handleTypeChange = ({ target: { value } }) => setType(value);
   const handleChannelChange = value => setChannelTextValue(value);
   const handleProductChange = value => setProductTextValue(value);
@@ -165,7 +178,14 @@ function ViewSignoff({ isNewSignoff, ...props }) {
     }
   };
 
-  const handleSignoffDelete = async () => {
+  const handleSignoffDelete = () =>
+    setDialogState({
+      ...dialogState,
+      open: true,
+      title: 'Delete Required Signoffs?',
+      confirmText: 'Delete',
+    });
+  const handleDialogSubmit = async () => {
     const { error } = await saveRS({
       product: productTextValue,
       channel: channelTextValue,
@@ -178,10 +198,17 @@ function ViewSignoff({ isNewSignoff, ...props }) {
       isNewSignoff,
     });
 
-    if (!error) {
-      props.history.push('/required-signoffs');
+    if (error) {
+      throw error;
     }
   };
+
+  const handleDialogClose = () => setDialogState(DIALOG_ACTION_INITIAL_STATE);
+  const handleDialogActionComplete = () => {
+    props.history.push('/required-signoffs');
+  };
+
+  const handleDialogError = error => setDialogState({ ...dialogState, error });
 
   useEffect(() => {
     if (isNewSignoff) {
@@ -342,6 +369,17 @@ function ViewSignoff({ isNewSignoff, ...props }) {
           )}
         </Fragment>
       )}
+      <DialogAction
+        open={dialogState.open}
+        title={dialogState.title}
+        body={dialogBody}
+        confirmText={dialogState.confirmText}
+        onSubmit={handleDialogSubmit}
+        onError={handleDialogError}
+        error={dialogState.error}
+        onComplete={handleDialogActionComplete}
+        onClose={handleDialogClose}
+      />
     </Dashboard>
   );
 }

--- a/src/views/RequiredSignoffs/ViewSignoff/index.jsx
+++ b/src/views/RequiredSignoffs/ViewSignoff/index.jsx
@@ -374,6 +374,7 @@ function ViewSignoff({ isNewSignoff, ...props }) {
         title={dialogState.title}
         body={dialogBody}
         confirmText={dialogState.confirmText}
+        destructive
         onSubmit={handleDialogSubmit}
         onError={handleDialogError}
         error={dialogState.error}

--- a/src/views/RequiredSignoffs/ViewSignoff/index.jsx
+++ b/src/views/RequiredSignoffs/ViewSignoff/index.jsx
@@ -335,7 +335,7 @@ function ViewSignoff({ isNewSignoff, ...props }) {
                 disabled={saveAction.loading}
                 icon={<DeleteIcon />}
                 tooltipOpen
-                tooltipTitle="Delete Signoff"
+                tooltipTitle="Delete Required Signoffs"
                 onClick={handleSignoffDelete}
               />
             </SpeedDial>

--- a/src/views/RequiredSignoffs/utils/updateRequiredSignoffs.js
+++ b/src/views/RequiredSignoffs/utils/updateRequiredSignoffs.js
@@ -1,5 +1,5 @@
 import {
-  deleteRequiredSignoff,
+  deleteScheduledChange,
   updateRequiredSignoff,
 } from '../../../services/requiredSignoffs';
 
@@ -56,7 +56,7 @@ export default params => {
         }
 
         if (role.sc && role.signoffs_required === role.sc.signoffs_required) {
-          return deleteRequiredSignoff({
+          return deleteScheduledChange({
             scId: role.sc.sc_id,
             type: channel ? 'product' : 'permissions',
             data_version: role.sc.data_version,
@@ -96,7 +96,7 @@ export default params => {
       removed.map(role => {
         // role doesn't exist yet, we should just delete that scheduled change
         if (role.sc && role.sc.change_type === 'insert') {
-          return deleteRequiredSignoff({
+          return deleteScheduledChange({
             scId: role.sc.sc_id,
             type: channel ? 'product' : 'permissions',
             data_version: role.sc.data_version,


### PR DESCRIPTION
This implements one-click deletions for Required Signoffs via the SpeedDial button (you can already do this, but you have to click the trash icon on each signoff on the page).

While testing this, I also noticed we never wired up the "Cancel Delete" button on `ListSignoffs`, so I did that as well.