### PR TITLE
Add selected style to a linked card (/rules, /releases)

### DIFF
--- a/src/views/Releases/ListReleases/index.jsx
+++ b/src/views/Releases/ListReleases/index.jsx
@@ -1,4 +1,5 @@
 import React, { useMemo, useState, useEffect } from 'react';
+import classNames from 'classnames';
 import PlusIcon from 'mdi-react/PlusIcon';
 import { makeStyles, useTheme } from '@material-ui/styles';
 import Fab from '@material-ui/core/Fab';
@@ -26,6 +27,9 @@ const useStyles = makeStyles(theme => ({
   },
   releaseCard: {
     margin: 2,
+  },
+  releaseCardSelected: {
+    border: `2px solid ${theme.palette.primary.light}`,
   },
 }));
 
@@ -196,7 +200,9 @@ function ListReleases(props) {
     return (
       <div key={release.name} style={style}>
         <ReleaseCard
-          className={classes.releaseCard}
+          className={classNames(classes.releaseCard, {
+            [classes.releaseCardSelected]: index === scrollToRow,
+          })}
           release={release}
           onAccessChange={handleAccessChange}
           onReleaseDelete={handleDelete}

--- a/src/views/Rules/ListRules/index.jsx
+++ b/src/views/Rules/ListRules/index.jsx
@@ -1,4 +1,5 @@
 import React, { Fragment, useEffect, useState, useMemo, useRef } from 'react';
+import classNames from 'classnames';
 import { stringify, parse } from 'qs';
 import { addSeconds } from 'date-fns';
 import Spinner from '@mozilla-frontend-infra/components/Spinner';
@@ -67,6 +68,9 @@ const useStyles = makeStyles(theme => ({
   },
   ruleCard: {
     margin: theme.spacing(1),
+  },
+  ruleCardSelected: {
+    border: `2px solid ${theme.palette.primary.light}`,
   },
 }));
 
@@ -680,7 +684,9 @@ function ListRules(props) {
         }
         style={style}>
         <RuleCard
-          className={classes.ruleCard}
+          className={classNames(classes.ruleCard, {
+            [classes.ruleCardSelected]: index === scrollToRow,
+          })}
           key={rule.rule_id}
           rule={rule}
           onRuleDelete={handleRuleDelete}


### PR DESCRIPTION
Many times when a user is navigated to the rules or releases page with an anchor (e.g, ?scId=24), the card doesn't always go to the top of the page. You can notice this when you try to link to cards at the end of the list. This is particularly annoying when being directed to a rule of type 'insert' where the scId is not even displayed on the card. This pull-request improves that experience:

![Screen Shot 2019-08-15 at 10 57 04 AM](https://user-images.githubusercontent.com/3766511/63103601-6e919d80-bf4b-11e9-8a0f-5dbd008cad18.png)
