### PR TITLE
Fix parsing of release history username.

### DIFF
--- a/src/services/releases.js
+++ b/src/services/releases.js
@@ -24,7 +24,7 @@ const getRevisions = (name, product) => {
           product,
           data_version: Number(dataVersion) ? dataVersion : parts[0],
           timestamp: parseInt(parts[1], 10),
-          changed_by: parts[2],
+          changed_by: parts.slice(2).join('-'),
           data_url: r.mediaLink,
         };
 


### PR DESCRIPTION
I noticed the current parsing doesn't work correctly when the username contains a hyphen, which is a bug in the code we carried over from the old UI.