### PR TITLE
Security header updates

### DIFF
--- a/.neutrinorc.js
+++ b/.neutrinorc.js
@@ -26,6 +26,8 @@ module.exports = {
               img-src: gravatar & githubusercontent & i1.wp.com for user avatars
                        (which can't be locked down to a specific path due to CSP format)
               style-src: https://fonts.googleapis.com for dynamically loaded fonts
+                         'unsafe-inline' because styled components need them
+                         TODO: we should look into using a nonce or hash to avoid this
               font-src: https://fonts.gstatic.com for fonts!
               connect-src: https://localhost:8010 for the backend api
                            https://www.googleapis.com/ for releases history

--- a/.neutrinorc.js
+++ b/.neutrinorc.js
@@ -26,7 +26,7 @@ module.exports = {
               img-src: gravatar & githubusercontent & i1.wp.com for user avatars
                        (which can't be locked down to a specific path due to CSP format)
               style-src: https://fonts.googleapis.com for dynamically loaded fonts
-                         'unsafe-inline' because styled components need them
+                         'unsafe-inline' because CSS-in-JS needs them
                          TODO: we should look into using a nonce or hash to avoid this
               font-src: https://fonts.gstatic.com for fonts!
               connect-src: https://localhost:8010 for the backend api

--- a/.neutrinorc.js
+++ b/.neutrinorc.js
@@ -35,12 +35,15 @@ module.exports = {
                            https://balrog-localdev.auth0.com for authentication.
                            note: this is different in stage/prod
               frame-src: https://balrog-localdev.auth0.com for background token refreshes
+              frame-ancestors: 'none' because nobody should be embedding this UI.
+              base-uri: 'none' because we don't have a <base> tag
+              form-action: 'none' because we don't submit forms
             */
-            'Content-Security-Policy': "default-src 'none'; script-src 'self' 'unsafe-eval'; img-src 'self' https://*.gravatar.com https://*.githubusercontent.com https://i1.wp.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src https://fonts.gstatic.com; connect-src https://localhost:8010 'self' https://balrog-localdev.auth0.com https://www.googleapis.com/; frame-src https://balrog-localdev.auth0.com",
+            'Content-Security-Policy': "default-src 'none'; script-src 'self' 'unsafe-eval'; img-src 'self' https://*.gravatar.com https://*.githubusercontent.com https://i1.wp.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src https://fonts.gstatic.com; connect-src https://localhost:8010 'self' https://balrog-localdev.auth0.com https://www.googleapis.com/; frame-src https://balrog-localdev.auth0.com; frame-ancestors 'none'; base-uri 'none'; form-action 'none'",
             'X-Frame-Options': 'SAMEORIGIN',
             'X-Content-Type-Options': 'nosniff',
             'X-XSS-Protection': '1; mode=block',
-            'Referrer-Policy': 'origin',
+            'Referrer-Policy': 'no-referrer',
             'Strict-Transport-Security': 'max-age=31536000; includeSubDomains; always;',
           },
         },


### PR DESCRIPTION
A few updates based on the Mozilla Observatory report (https://observatory.mozilla.org/analyze/balrog-admin-static-stage.stage.mozaws.net). I'd like to get rid of 'unsafe-inline' for style-src, but it looks like a pretty tricky affair, so I'm going to defer it for now.