### PR TITLE
Implement Release view mutations

### DIFF
--- a/src/components/ReleaseCard/index.jsx
+++ b/src/components/ReleaseCard/index.jsx
@@ -198,14 +198,12 @@ function ReleaseCard(props) {
             Update
           </Button>
         </Link>
-        {!hasRulesPointingAtRevision && (
-          <Button
-            disabled={release.read_only}
-            color="secondary"
-            onClick={() => onReleaseDelete(release)}>
-            Delete
-          </Button>
-        )}
+        <Button
+          disabled={release.read_only || hasRulesPointingAtRevision}
+          color="secondary"
+          onClick={() => onReleaseDelete(release)}>
+          Delete
+        </Button>
       </CardActions>
     </Card>
   );

--- a/src/hooks/useAction.js
+++ b/src/hooks/useAction.js
@@ -17,12 +17,12 @@ export default action => {
   const [data, setData] = useState(null);
   const [error, setError] = useState(null);
   const state = { loading, data, error };
-  const performAction = async body => {
+  const performAction = async (...body) => {
     try {
       setLoading(true);
       setData(null);
       setError(null);
-      const data = await action(body);
+      const data = await action(...body);
 
       setData(data);
 

--- a/src/services/releases.js
+++ b/src/services/releases.js
@@ -51,6 +51,10 @@ const getRevisions = (name, product) => {
   return getReleases(`${bucket}?prefix=${name}/&delimeter=/`);
 };
 
+const getScheduledChangeByName = name =>
+  axios.get(`/scheduled_changes/releases?name=${name}`);
+const getScheduledChangeByScId = scId =>
+  axios.get(`/scheduled_changes/releases/${scId}`);
 const createRelease = (name, product, blob) =>
   axios.post(`/releases`, { name, product, blob });
 const addScheduledChange = data => axios.post('/scheduled_changes/releases', data);
@@ -63,6 +67,8 @@ export {
   getReleaseNames,
   deleteRelease,
   getRevisions,
+  getScheduledChangeByName,
+  getScheduledChangeByScId,
   createRelease,
   addScheduledChange,
 };

--- a/src/services/releases.js
+++ b/src/services/releases.js
@@ -60,6 +60,11 @@ const createRelease = (name, product, blob) =>
 const addScheduledChange = data => axios.post('/scheduled_changes/releases', data);
 const updateScheduledChange = ({ scId, ...data }) =>
   axios.post(`/scheduled_changes/releases/${scId}`, data);
+const deleteScheduledChange = ({ scId, scDataVersion }) =>
+  // The backend wants sc_data_version, but calls it data_version.
+  axios.delete(`/scheduled_changes/releases/${scId}`, {
+    params: { data_version: scDataVersion },
+  });
 
 // Releases factory
 // eslint-disable-next-line import/prefer-default-export
@@ -74,4 +79,5 @@ export {
   createRelease,
   addScheduledChange,
   updateScheduledChange,
+  deleteScheduledChange,
 };

--- a/src/services/releases.js
+++ b/src/services/releases.js
@@ -53,6 +53,7 @@ const getRevisions = (name, product) => {
 
 const createRelease = (name, product, blob) =>
   axios.post(`/releases`, { name, product, blob });
+const addScheduledChange = data => axios.post('/scheduled_changes/releases', data);
 
 // Releases factory
 // eslint-disable-next-line import/prefer-default-export
@@ -63,4 +64,5 @@ export {
   deleteRelease,
   getRevisions,
   createRelease,
+  addScheduledChange,
 };

--- a/src/services/releases.js
+++ b/src/services/releases.js
@@ -51,6 +51,9 @@ const getRevisions = (name, product) => {
   return getReleases(`${bucket}?prefix=${name}/&delimeter=/`);
 };
 
+const createRelease = (name, product, blob) =>
+  axios.post(`/releases`, { name, product, blob });
+
 // Releases factory
 // eslint-disable-next-line import/prefer-default-export
 export {
@@ -59,4 +62,5 @@ export {
   getReleaseNames,
   deleteRelease,
   getRevisions,
+  createRelease,
 };

--- a/src/services/releases.js
+++ b/src/services/releases.js
@@ -53,8 +53,6 @@ const getRevisions = (name, product) => {
 
 const getScheduledChangeByName = name =>
   axios.get(`/scheduled_changes/releases?name=${name}`);
-const getScheduledChangeByScId = scId =>
-  axios.get(`/scheduled_changes/releases/${scId}`);
 const createRelease = (name, product, blob) =>
   axios.post(`/releases`, { name, product, blob });
 const addScheduledChange = data => axios.post('/scheduled_changes/releases', data);
@@ -75,7 +73,6 @@ export {
   deleteRelease,
   getRevisions,
   getScheduledChangeByName,
-  getScheduledChangeByScId,
   createRelease,
   addScheduledChange,
   updateScheduledChange,

--- a/src/services/releases.js
+++ b/src/services/releases.js
@@ -55,7 +55,8 @@ const getScheduledChangeByName = name =>
   axios.get(`/scheduled_changes/releases?name=${name}`);
 const createRelease = (name, product, blob) =>
   axios.post(`/releases`, { name, product, blob });
-const addScheduledChange = data => axios.post('/scheduled_changes/releases', data);
+const addScheduledChange = data =>
+  axios.post('/scheduled_changes/releases', data);
 const updateScheduledChange = ({ scId, ...data }) =>
   axios.post(`/scheduled_changes/releases/${scId}`, data);
 const deleteScheduledChange = ({ scId, scDataVersion }) =>

--- a/src/services/releases.js
+++ b/src/services/releases.js
@@ -58,6 +58,8 @@ const getScheduledChangeByScId = scId =>
 const createRelease = (name, product, blob) =>
   axios.post(`/releases`, { name, product, blob });
 const addScheduledChange = data => axios.post('/scheduled_changes/releases', data);
+const updateScheduledChange = ({ scId, ...data }) =>
+  axios.post(`/scheduled_changes/releases/${scId}`, data);
 
 // Releases factory
 // eslint-disable-next-line import/prefer-default-export
@@ -71,4 +73,5 @@ export {
   getScheduledChangeByScId,
   createRelease,
   addScheduledChange,
+  updateScheduledChange,
 };

--- a/src/views/Releases/Release/index.jsx
+++ b/src/views/Releases/Release/index.jsx
@@ -14,7 +14,15 @@ import SpeedDial from '../../../components/SpeedDial';
 import AutoCompleteText from '../../../components/AutoCompleteText';
 import CodeEditor from '../../../components/CodeEditor';
 import useAction from '../../../hooks/useAction';
-import { getReleases, getRelease, createRelease, addScheduledChange, updateScheduledChange, deleteScheduledChange, getScheduledChangeByName } from '../../../services/releases';
+import {
+  getReleases,
+  getRelease,
+  createRelease,
+  addScheduledChange,
+  updateScheduledChange,
+  deleteScheduledChange,
+  getScheduledChangeByName,
+} from '../../../services/releases';
 import { getProducts } from '../../../services/rules';
 import getSuggestions from '../../../components/AutoCompleteText/getSuggestions';
 
@@ -47,7 +55,6 @@ export default function Release(props) {
   const [scId, setScId] = useState(null);
   const [dataVersion, setDataVersion] = useState(null);
   const [scDataVersion, setScDataVersion] = useState(null);
-  const [hasRules, setHasRules] = useState(false);
   const [release, fetchRelease] = useAction(getRelease);
   const [createRelAction, createRel] = useAction(createRelease);
   const [addSCAction, addSC] = useAction(addScheduledChange);
@@ -58,9 +65,21 @@ export default function Release(props) {
   );
   const fetchReleases = useAction(getReleases)[1];
   const [products, fetchProducts] = useAction(getProducts);
-  const isLoading = release.loading || products.loading || scheduledChangeActionName.loading;
-  const actionLoading = createRelAction.loading || addSCAction.loading || updateSCAction.loading || deleteSCAction.loading;
-  const error = release.error || products.error || createRelAction.error || addSCAction.error || updateSCAction.error || deleteSCAction.error || scheduledChangeActionName.error;
+  const isLoading =
+    release.loading || products.loading || scheduledChangeActionName.loading;
+  const actionLoading =
+    createRelAction.loading ||
+    addSCAction.loading ||
+    updateSCAction.loading ||
+    deleteSCAction.loading;
+  const error =
+    release.error ||
+    products.error ||
+    createRelAction.error ||
+    addSCAction.error ||
+    updateSCAction.error ||
+    deleteSCAction.error ||
+    scheduledChangeActionName.error;
 
   useEffect(() => {
     if (releaseName) {
@@ -68,41 +87,30 @@ export default function Release(props) {
         fetchRelease(releaseName),
         fetchScheduledChangeByName(releaseName),
         fetchReleases(),
-      ]).then(
-        ([fetchedRelease, fetchedSC, fetchedReleases]) => {
-          if (fetchedSC.data.data.count > 0) {
-            const sc = fetchedSC.data.data.scheduled_changes[0];
-            setReleaseEditorValue(
-              JSON.stringify(sc.data, null, 2)
-            );
-            setProductTextValue(sc.product);
-            setDataVersion(sc.data_version);
-            setScId(sc.sc_id);
-            setScDataVersion(sc.sc_data_version);
-            if (sc.change_type !== 'insert' && fetchedReleases.data) {
-              const r = fetchedReleases.data.data.releases.find(
-                r => r.name === releaseName
-              );
+      ]).then(([fetchedRelease, fetchedSC, fetchedReleases]) => {
+        if (fetchedSC.data.data.count > 0) {
+          const sc = fetchedSC.data.data.scheduled_changes[0];
 
-              setHasRules(r.rule_ids.length > 0);
-            } 
-          } else {
-            setReleaseEditorValue(
-              JSON.stringify(fetchedRelease.data.data, null, 2)
+          setReleaseEditorValue(JSON.stringify(sc.data, null, 2));
+          setProductTextValue(sc.product);
+          setDataVersion(sc.data_version);
+          setScId(sc.sc_id);
+          setScDataVersion(sc.sc_data_version);
+        } else {
+          setReleaseEditorValue(
+            JSON.stringify(fetchedRelease.data.data, null, 2)
+          );
+
+          if (fetchedReleases.data) {
+            const r = fetchedReleases.data.data.releases.find(
+              r => r.name === releaseName
             );
 
-            if (fetchedReleases.data) {
-              const r = fetchedReleases.data.data.releases.find(
-                r => r.name === releaseName
-              );
-  
-              setProductTextValue(r.product);
-              setDataVersion(r.data_version);
-              setHasRules(r.rule_ids.length > 0);
-            }
+            setProductTextValue(r.product);
+            setDataVersion(r.data_version);
           }
         }
-      );
+      });
     }
 
     fetchProducts();
@@ -121,39 +129,46 @@ export default function Release(props) {
   };
 
   const handleReleaseCreate = async () => {
-    const { error } = await createRel(releaseNameValue, productTextValue, releaseEditorValue);
+    const { error } = await createRel(
+      releaseNameValue,
+      productTextValue,
+      releaseEditorValue
+    );
 
     if (!error) {
       props.history.push(`/releases#${releaseNameValue}`);
     }
   };
+
   const handleReleaseUpdate = async () => {
     // todo: handle updating an existing scheduled change
-    const when = (new Date()).getTime() + 5000;
+    const when = new Date().getTime() + 5000;
+    let error = null;
 
     if (scId) {
-      const { error } = await updateSC({
+      ({ error } = await updateSC({
         scId,
         when,
         sc_data_version: scDataVersion,
         data_version: dataVersion,
         data: releaseEditorValue,
-      });
+      }));
     } else {
-      const { error } = await addSC({
+      ({ error } = await addSC({
         change_type: 'update',
         when,
         name: releaseNameValue,
         product: productTextValue,
         data: releaseEditorValue,
         data_version: dataVersion,
-      });
+      }));
     }
 
     if (!error) {
       props.history.push(`/releases#${releaseNameValue}`);
     }
   };
+
   const handleScheduledChangeDelete = async () => {
     const { error } = await deleteSC({
       scId,
@@ -162,7 +177,7 @@ export default function Release(props) {
 
     if (!error) {
       props.history.push(`/releases#${releaseNameValue}`);
-    };
+    }
   };
 
   return (

--- a/src/views/Releases/Release/index.jsx
+++ b/src/views/Releases/Release/index.jsx
@@ -14,7 +14,7 @@ import SpeedDial from '../../../components/SpeedDial';
 import AutoCompleteText from '../../../components/AutoCompleteText';
 import CodeEditor from '../../../components/CodeEditor';
 import useAction from '../../../hooks/useAction';
-import { getReleases, getRelease, createRelease, deleteRelease, addScheduledChange, updateScheduledChange, getScheduledChangeByName, getScheduledChangeByScId } from '../../../services/releases';
+import { getReleases, getRelease, createRelease, addScheduledChange, updateScheduledChange, deleteScheduledChange, getScheduledChangeByName, getScheduledChangeByScId } from '../../../services/releases';
 import { getProducts } from '../../../services/rules';
 import getSuggestions from '../../../components/AutoCompleteText/getSuggestions';
 
@@ -50,9 +50,9 @@ export default function Release(props) {
   const [hasRules, setHasRules] = useState(false);
   const [release, fetchRelease] = useAction(getRelease);
   const [createRelAction, createRel] = useAction(createRelease);
-  const [delReleaseAction, delRelease] = useAction(deleteRelease);
   const [addSCAction, addSC] = useAction(addScheduledChange);
   const [updateSCAction, updateSC] = useAction(updateScheduledChange);
+  const [deleteSCAction, deleteSC] = useAction(deleteScheduledChange);
   const [scheduledChangeActionName, fetchScheduledChangeByName] = useAction(
     getScheduledChangeByName
   );
@@ -63,8 +63,8 @@ export default function Release(props) {
   const [products, fetchProducts] = useAction(getProducts);
   const isLoading = release.loading || products.loading || scheduledChangeActionName.loading || scheduledChangeActionScId.loading;
   // TODO: Fill actionLoading when hooking up mutations
-  const actionLoading = createRelAction.loading || delReleaseAction.loading || addSCAction.loading || updateSCAction.loading;
-  const error = release.error || products.error || createRelAction.error || delReleaseAction.error || addSCAction.error || updateSCAction.error || scheduledChangeActionName.error || scheduledChangeActionScId.error;
+  const actionLoading = createRelAction.loading || addSCAction.loading || updateSCAction.loading || deleteSCAction.loading;
+  const error = release.error || products.error || createRelAction.error || addSCAction.error || updateSCAction.error || deleteSCAction.error || scheduledChangeActionName.error || scheduledChangeActionScId.error;
 
   useEffect(() => {
     if (releaseName) {
@@ -158,14 +158,14 @@ export default function Release(props) {
       props.history.push(`/releases#${releaseNameValue}`);
     }
   };
-  const handleReleaseDelete = async () => {
-    const { error } = await delRelease({
-      name: releaseNameValue,
-      dataVersion,
+  const handleScheduledChangeDelete = async () => {
+    const { error } = await deleteSC({
+      scId,
+      scDataVersion,
     });
 
     if (!error) {
-      props.history.push('/releases');
+      props.history.push(`/releases#${releaseNameValue}`);
     };
   };
 
@@ -222,14 +222,14 @@ export default function Release(props) {
                 <ContentSaveIcon />
               </Fab>
             </Tooltip>
-            {!isNewRelease && (
+            {!isNewRelease && scId && (
               <SpeedDial ariaLabel="Secondary Actions">
                 <SpeedDialAction
-                  disabled={actionLoading || hasRules}
+                  disabled={actionLoading}
                   icon={<DeleteIcon />}
                   tooltipOpen
-                  tooltipTitle="Delete Release"
-                  onClick={handleReleaseDelete}
+                  tooltipTitle="Cancel Pending Change"
+                  onClick={handleScheduledChangeDelete}
                 />
               </SpeedDial>
             )}

--- a/src/views/Releases/Release/index.jsx
+++ b/src/views/Releases/Release/index.jsx
@@ -61,13 +61,13 @@ export default function Release(props) {
   const [addSCAction, addSC] = useAction(addScheduledChange);
   const [updateSCAction, updateSC] = useAction(updateScheduledChange);
   const [deleteSCAction, deleteSC] = useAction(deleteScheduledChange);
-  const [scheduledChangeActionName, fetchScheduledChangeByName] = useAction(
+  const [scheduledChangeNameAction, fetchScheduledChangeByName] = useAction(
     getScheduledChangeByName
   );
   const fetchReleases = useAction(getReleases)[1];
   const [products, fetchProducts] = useAction(getProducts);
   const isLoading =
-    release.loading || products.loading || scheduledChangeActionName.loading;
+    release.loading || products.loading || scheduledChangeNameAction.loading;
   const actionLoading =
     createRelAction.loading ||
     addSCAction.loading ||
@@ -80,7 +80,7 @@ export default function Release(props) {
     addSCAction.error ||
     updateSCAction.error ||
     deleteSCAction.error ||
-    scheduledChangeActionName.error;
+    scheduledChangeNameAction.error;
 
   useEffect(() => {
     if (releaseName) {
@@ -131,6 +131,8 @@ export default function Release(props) {
   };
 
   const handleReleaseCreate = async () => {
+    // Newly created Releases never need signoff, so we can always
+    // safely create them directly instead of using Scheduled Changes.
     const { error } = await createRel(
       releaseNameValue,
       productTextValue,
@@ -143,7 +145,12 @@ export default function Release(props) {
   };
 
   const handleReleaseUpdate = async () => {
-    // todo: handle updating an existing scheduled change
+    // Updates to Releases require signoff in some circumstances,
+    // but we don't have a need to schedule them for specific times.
+    // Because of this, we always schedule them for slightly in the future,
+    // which means that changes that don't require signoff will happen
+    // almost immediately, and changes that do require signoff will wait
+    // until those are completed.
     const when = new Date().getTime() + 5000;
     let error = null;
 

--- a/src/views/Releases/Release/index.jsx
+++ b/src/views/Releases/Release/index.jsx
@@ -14,7 +14,7 @@ import SpeedDial from '../../../components/SpeedDial';
 import AutoCompleteText from '../../../components/AutoCompleteText';
 import CodeEditor from '../../../components/CodeEditor';
 import useAction from '../../../hooks/useAction';
-import { getReleases, getRelease } from '../../../services/releases';
+import { getReleases, getRelease, createRelease } from '../../../services/releases';
 import { getProducts } from '../../../services/rules';
 import getSuggestions from '../../../components/AutoCompleteText/getSuggestions';
 
@@ -45,12 +45,13 @@ export default function Release(props) {
   const [productTextValue, setProductTextValue] = useState('');
   const [releaseEditorValue, setReleaseEditorValue] = useState('{}');
   const [release, fetchRelease] = useAction(getRelease);
+  const [createRelAction, createRel] = useAction(createRelease);
   const fetchReleases = useAction(getReleases)[1];
   const [products, fetchProducts] = useAction(getProducts);
   const isLoading = release.loading || products.loading;
   // TODO: Fill actionLoading when hooking up mutations
-  const actionLoading = false;
-  const error = release.error || products.error;
+  const actionLoading = createRelAction.loading;
+  const error = release.error || products.error || createRelAction.error;
 
   useEffect(() => {
     if (releaseName) {
@@ -88,8 +89,13 @@ export default function Release(props) {
     setReleaseEditorValue(value);
   };
 
-  // TODO: Add mutations
-  const handleReleaseCreate = () => {};
+  const handleReleaseCreate = async () => {
+    const { error } = await createRel(releaseNameValue, productTextValue, releaseEditorValue);
+
+    if (!error) {
+      props.history.push(`/releases#${releaseNameValue}`);
+    }
+  };
   const handleReleaseUpdate = () => {};
   const handleReleaseDelete = () => {};
 

--- a/src/views/Releases/Release/index.jsx
+++ b/src/views/Releases/Release/index.jsx
@@ -243,10 +243,10 @@ export default function Release(props) {
                 <ContentSaveIcon />
               </Fab>
             </Tooltip>
-            {!isNewRelease && scId && (
+            {!isNewRelease && (
               <SpeedDial ariaLabel="Secondary Actions">
                 <SpeedDialAction
-                  disabled={actionLoading || isReadOnly}
+                  disabled={actionLoading || isReadOnly || !scId}
                   icon={<DeleteIcon />}
                   tooltipOpen
                   tooltipTitle="Cancel Pending Change"

--- a/src/views/Releases/Release/index.jsx
+++ b/src/views/Releases/Release/index.jsx
@@ -14,7 +14,7 @@ import SpeedDial from '../../../components/SpeedDial';
 import AutoCompleteText from '../../../components/AutoCompleteText';
 import CodeEditor from '../../../components/CodeEditor';
 import useAction from '../../../hooks/useAction';
-import { getReleases, getRelease, createRelease, addScheduledChange, updateScheduledChange, deleteScheduledChange, getScheduledChangeByName, getScheduledChangeByScId } from '../../../services/releases';
+import { getReleases, getRelease, createRelease, addScheduledChange, updateScheduledChange, deleteScheduledChange, getScheduledChangeByName } from '../../../services/releases';
 import { getProducts } from '../../../services/rules';
 import getSuggestions from '../../../components/AutoCompleteText/getSuggestions';
 
@@ -56,15 +56,11 @@ export default function Release(props) {
   const [scheduledChangeActionName, fetchScheduledChangeByName] = useAction(
     getScheduledChangeByName
   );
-  const [scheduledChangeActionScId, fetchScheduledChangeByScId] = useAction(
-    getScheduledChangeByScId
-  );
   const fetchReleases = useAction(getReleases)[1];
   const [products, fetchProducts] = useAction(getProducts);
-  const isLoading = release.loading || products.loading || scheduledChangeActionName.loading || scheduledChangeActionScId.loading;
-  // TODO: Fill actionLoading when hooking up mutations
+  const isLoading = release.loading || products.loading || scheduledChangeActionName.loading;
   const actionLoading = createRelAction.loading || addSCAction.loading || updateSCAction.loading || deleteSCAction.loading;
-  const error = release.error || products.error || createRelAction.error || addSCAction.error || updateSCAction.error || deleteSCAction.error || scheduledChangeActionName.error || scheduledChangeActionScId.error;
+  const error = release.error || products.error || createRelAction.error || addSCAction.error || updateSCAction.error || deleteSCAction.error || scheduledChangeActionName.error;
 
   useEffect(() => {
     if (releaseName) {


### PR DESCRIPTION
There's a few other small fixes/changes here too:
* Ensure `useAction` always passes along all positional arguments.
* Disable `Delete` button on `ReleaseCard` instead of hiding it when a Release has Rules pointing at it.
* Replace the `Delete Release` button on the `Release` view with `Cancel Pending Change` (like we have for Rules).