### PR TITLE
Redirect from rules/rules revisions pages with previous filter

### DIFF
--- a/src/components/ReleaseCard/index.jsx
+++ b/src/components/ReleaseCard/index.jsx
@@ -96,7 +96,7 @@ const useStyles = makeStyles(theme => ({
 function ReleaseCard(props) {
   const { release, onAccessChange, onReleaseDelete, ...rest } = props;
   const classes = useStyles();
-  const hasRulesPointingAtRevision = Object.keys(release.rule_ids).length > 0;
+  const hasRulesPointingAtRevision = Object.keys(release.rule_info).length > 0;
   const handleAccessChange = ({ target: { checked } }) => {
     onAccessChange({ release, checked });
   };

--- a/src/components/ReleaseCard/index.jsx
+++ b/src/components/ReleaseCard/index.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { stringify } from 'qs';
 import { func } from 'prop-types';
 import { makeStyles } from '@material-ui/styles';
 import Card from '@material-ui/core/Card';
@@ -95,7 +96,7 @@ const useStyles = makeStyles(theme => ({
 function ReleaseCard(props) {
   const { release, onAccessChange, onReleaseDelete, ...rest } = props;
   const classes = useStyles();
-  const hasRulesPointingAtRevision = release.rule_ids.length > 0;
+  const hasRulesPointingAtRevision = Object.keys(release.rule_ids).length > 0;
   const handleAccessChange = ({ target: { checked } }) => {
     onAccessChange({ release, checked });
   };
@@ -168,11 +169,14 @@ function ReleaseCard(props) {
                   secondaryTypographyProps={{ component: 'div' }}
                   secondary={
                     hasRulesPointingAtRevision ? (
-                      release.rule_ids.map(ruleId => (
+                      // todo: need to adjust channel. don't set if not present
+                      // get rid of trailing - and *
+                      // add rule id to hash filter
+                      Object.entries(release.rule_info).map(([ruleId, ruleInfo]) => (
                         <Link
                           className={classes.link}
                           key={ruleId}
-                          to={`/rules/${ruleId}`}>
+                          to={`/rules${stringify({ product: ruleInfo.product, channel: ruleInfo.channel }, { addQueryPrefix: true })}`}>
                           <Chip
                             clickable
                             size="small"

--- a/src/components/ReleaseCard/index.jsx
+++ b/src/components/ReleaseCard/index.jsx
@@ -101,6 +101,18 @@ function ReleaseCard(props) {
     onAccessChange({ release, checked });
   };
 
+  const getRuleLink = (ruleId, product, channel) => {
+    const args = { product };
+
+    if (channel) {
+      args.channel = channel.replace(/[-*]*$/, '');
+    }
+
+    const qs = stringify(args, { addQueryPrefix: true });
+
+    return `/rules${qs}#ruleId=${ruleId}`;
+  };
+
   return (
     <Card classes={{ root: classes.root }} {...rest}>
       <CardHeader
@@ -169,23 +181,26 @@ function ReleaseCard(props) {
                   secondaryTypographyProps={{ component: 'div' }}
                   secondary={
                     hasRulesPointingAtRevision ? (
-                      // todo: need to adjust channel. don't set if not present
-                      // get rid of trailing - and *
-                      // add rule id to hash filter
-                      Object.entries(release.rule_info).map(([ruleId, ruleInfo]) => (
-                        <Link
-                          className={classes.link}
-                          key={ruleId}
-                          to={`/rules${stringify({ product: ruleInfo.product, channel: ruleInfo.channel }, { addQueryPrefix: true })}`}>
-                          <Chip
-                            clickable
-                            size="small"
-                            icon={<LinkIcon />}
-                            label={ruleId}
-                            className={classes.chip}
-                          />
-                        </Link>
-                      ))
+                      Object.entries(release.rule_info).map(
+                        ([ruleId, ruleInfo]) => (
+                          <Link
+                            className={classes.link}
+                            key={ruleId}
+                            to={getRuleLink(
+                              ruleId,
+                              ruleInfo.product,
+                              ruleInfo.channel
+                            )}>
+                            <Chip
+                              clickable
+                              size="small"
+                              icon={<LinkIcon />}
+                              label={ruleId}
+                              className={classes.chip}
+                            />
+                          </Link>
+                        )
+                      )
                     ) : (
                       <em>n/a</em>
                     )

--- a/src/components/RuleCard/index.jsx
+++ b/src/components/RuleCard/index.jsx
@@ -134,6 +134,7 @@ const useStyles = makeStyles(theme => ({
 
 function RuleCard({
   rule,
+  rulesFilter,
   onRuleDelete,
   onSignoff,
   onRevoke,
@@ -219,7 +220,11 @@ function RuleCard({
           }
           action={
             !readOnly ? (
-              <Link to={`/rules/${rule.rule_id}/revisions`}>
+              <Link
+                to={{
+                  pathname: `/rules/${rule.rule_id}/revisions`,
+                  state: { rulesFilter },
+                }}>
                 <Tooltip title="Revisions">
                   <IconButton>
                     <HistoryIcon />
@@ -720,6 +725,7 @@ function RuleCard({
                 pathname: '/rules/create',
                 state: {
                   rule,
+                  rulesFilter,
                 },
               }}>
               <Button color="secondary">Duplicate</Button>
@@ -732,11 +738,14 @@ function RuleCard({
           {user ? (
             <Link
               className={classes.link}
-              to={
-                rule.rule_id
+              to={{
+                pathname: rule.rule_id
                   ? `/rules/${rule.rule_id}`
-                  : `/rules/create/${rule.scheduledChange.sc_id}`
-              }>
+                  : `/rules/create/${rule.scheduledChange.sc_id}`,
+                state: {
+                  rulesFilter,
+                },
+              }}>
               <Button color="secondary">Update</Button>
             </Link>
           ) : (

--- a/src/utils/prop-types.js
+++ b/src/utils/prop-types.js
@@ -39,5 +39,10 @@ export const release = shape({
   product: string,
   read_only: bool,
   required_signoffs: object,
-  rule_info: object,
+  rule_info: shape({
+    rule_id: shape({
+      channel: string,
+      product: string,
+    }),
+  }),
 });

--- a/src/utils/prop-types.js
+++ b/src/utils/prop-types.js
@@ -4,7 +4,6 @@ import {
   shape,
   string,
   oneOfType,
-  arrayOf,
   object,
 } from 'prop-types';
 
@@ -47,5 +46,5 @@ export const release = shape({
   product: string,
   read_only: bool,
   required_signoffs: object,
-  rule_ids: arrayOf(number),
+  rule_info: object,
 });

--- a/src/utils/prop-types.js
+++ b/src/utils/prop-types.js
@@ -1,11 +1,4 @@
-import {
-  bool,
-  number,
-  shape,
-  string,
-  oneOfType,
-  object,
-} from 'prop-types';
+import { bool, number, shape, string, oneOfType, object } from 'prop-types';
 
 export const signoffEntry = shape({
   channel: string,

--- a/src/views/Releases/ListReleases/index.jsx
+++ b/src/views/Releases/ListReleases/index.jsx
@@ -253,7 +253,7 @@ function ListReleases(props) {
     const listItemTextMargin = 6;
     const release = filteredReleases[index];
     // An approximation
-    const ruleIdsLineCount = Math.ceil(release.rule_ids.length / 10) || 1;
+    const ruleIdsLineCount = Math.ceil(Object.keys(release.rule_info).length / 10) || 1;
     // card header
     let height = h6TextHeight + body1TextHeight() + theme.spacing(2);
 

--- a/src/views/Releases/ListReleases/index.jsx
+++ b/src/views/Releases/ListReleases/index.jsx
@@ -253,7 +253,8 @@ function ListReleases(props) {
     const listItemTextMargin = 6;
     const release = filteredReleases[index];
     // An approximation
-    const ruleIdsLineCount = Math.ceil(Object.keys(release.rule_info).length / 10) || 1;
+    const ruleIdsLineCount =
+      Math.ceil(Object.keys(release.rule_info).length / 10) || 1;
     // card header
     let height = h6TextHeight + body1TextHeight() + theme.spacing(2);
 

--- a/src/views/Rules/ListRuleRevisions/index.jsx
+++ b/src/views/Rules/ListRuleRevisions/index.jsx
@@ -56,23 +56,10 @@ function ListRuleRevisions(props) {
     : [];
   const revisionsCount = revisions.length;
   const redirectWithRulesFilter = hashFilter => {
-    const queryString = {};
+    const [product, channel] = rulesFilter;
+    const query = stringify({ product, channel }, { addQueryPrefix: true });
 
-    if (rulesFilter.length > 0) {
-      // eslint-disable-next-line prefer-destructuring
-      queryString.product = rulesFilter[0];
-
-      if (rulesFilter.length > 1 && rulesFilter[1]) {
-        // eslint-disable-next-line prefer-destructuring
-        queryString.channel = rulesFilter[1];
-      }
-    }
-
-    props.history.push(
-      `/rules?${
-        Object.keys(queryString).length > 0 ? stringify(queryString) : ''
-      }#${hashFilter}`
-    );
+    props.history.push(`/rules${query}#${hashFilter}`);
   };
 
   useEffect(() => {

--- a/src/views/Rules/ListRuleRevisions/index.jsx
+++ b/src/views/Rules/ListRuleRevisions/index.jsx
@@ -1,6 +1,7 @@
 import React, { Fragment, useState, useEffect } from 'react';
 import { Column } from 'react-virtualized';
 import { clone } from 'ramda';
+import { stringify } from 'qs';
 import Spinner from '@mozilla-frontend-infra/components/Spinner';
 import { makeStyles } from '@material-ui/styles';
 import Typography from '@material-ui/core/Typography';
@@ -36,6 +37,10 @@ const useStyles = makeStyles({
 
 function ListRuleRevisions(props) {
   const classes = useStyles();
+  const rulesFilter =
+    props.location.state && props.location.state.rulesFilter
+      ? props.location.state.rulesFilter
+      : [];
   const [drawerState, setDrawerState] = useState({ open: false, item: {} });
   const [leftRadioCheckedIndex, setLeftRadioCheckedIndex] = useState(1);
   const [rightRadioCheckedIndex, setRightRadioCheckedIndex] = useState(0);
@@ -50,6 +55,25 @@ function ListRuleRevisions(props) {
     ? fetchedRevisions.data.data.rules
     : [];
   const revisionsCount = revisions.length;
+  const redirectWithRulesFilter = hashFilter => {
+    const queryString = {};
+
+    if (rulesFilter.length > 0) {
+      // eslint-disable-next-line prefer-destructuring
+      queryString.product = rulesFilter[0];
+
+      if (rulesFilter.length > 1 && rulesFilter[1]) {
+        // eslint-disable-next-line prefer-destructuring
+        queryString.channel = rulesFilter[1];
+      }
+    }
+
+    props.history.push(
+      `/rules?${
+        Object.keys(queryString).length > 0 ? stringify(queryString) : ''
+      }#${hashFilter}`
+    );
+  };
 
   useEffect(() => {
     fetchRevisions(ruleId);
@@ -114,7 +138,7 @@ function ListRuleRevisions(props) {
 
   const handleDialogClose = () => setDialogState(DIALOG_ACTION_INITIAL_STATE);
   const handleDialogActionComplete = scId =>
-    props.history.push(`/rules#scId=${scId}`);
+    redirectWithRulesFilter(`scId=${scId}`);
   const handleDialogError = error => setDialogState({ ...dialogState, error });
   const columnWidth = CONTENT_MAX_WIDTH / 4;
 

--- a/src/views/Rules/ListRules/index.jsx
+++ b/src/views/Rules/ListRules/index.jsx
@@ -96,11 +96,7 @@ function ListRules(props) {
   );
   const [productChannelOptions, setProductChannelOptions] = useState([]);
   const searchQueries = query.product ? [query.product, query.channel] : null;
-  const [productChannelFilter, setProductChannelFilter] = useState(
-    searchQueries
-      ? searchQueries.filter(Boolean).join(productChannelSeparator)
-      : ALL
-  );
+  const [productChannelFilter, setProductChannelFilter] = useState(ALL);
   const [dialogState, setDialogState] = useState(DIALOG_ACTION_INITIAL_STATE);
   const [dialogMode, setDialogMode] = useState('delete');
   const [scheduleDeleteDate, setScheduleDeleteDate] = useState(
@@ -283,9 +279,17 @@ function ListRules(props) {
     }
   }, [username]);
 
+  useEffect(() => {
+    setProductChannelFilter(
+      searchQueries
+        ? searchQueries.filter(Boolean).join(productChannelSeparator)
+        : ALL
+    );
+  }, [searchQueries]);
+
   const filteredRulesWithScheduledChanges = useMemo(
     () =>
-      productChannelFilter === ALL
+      productChannelFilter === ALL || !searchQueries
         ? rulesWithScheduledChanges
         : rulesWithScheduledChanges.filter(rule => {
             const [productFilter, channelFilter] = searchQueries;
@@ -309,7 +313,7 @@ function ListRules(props) {
 
             return true;
           }),
-    [productChannelFilter, rulesWithScheduledChanges]
+    [searchQueries, productChannelFilter, rulesWithScheduledChanges]
   );
   const handleDateTimePickerError = error => {
     setDateTimePickerError(error);

--- a/src/views/Rules/ListRules/index.jsx
+++ b/src/views/Rules/ListRules/index.jsx
@@ -689,6 +689,7 @@ function ListRules(props) {
           })}
           key={rule.rule_id}
           rule={rule}
+          rulesFilter={searchQueries}
           onRuleDelete={handleRuleDelete}
           onSignoff={() => handleSignoff(rule)}
           onRevoke={() => handleRevoke(rule)}
@@ -757,7 +758,11 @@ function ListRules(props) {
               />
             </Fragment>
           )}
-          <Link to="/rules/create">
+          <Link
+            to={{
+              pathname: '/rules/create',
+              state: { rulesFilter: searchQueries },
+            }}>
             <Tooltip title="Add Rule">
               <Fab color="primary" className={classes.fab}>
                 <PlusIcon />

--- a/src/views/Rules/Rule/index.jsx
+++ b/src/views/Rules/Rule/index.jsx
@@ -2,6 +2,7 @@ import React, { Fragment, useState, useEffect } from 'react';
 import classNames from 'classnames';
 import { bool } from 'prop-types';
 import { defaultTo, assocPath } from 'ramda';
+import { stringify } from 'qs';
 import NumberFormat from 'react-number-format';
 import { makeStyles } from '@material-ui/styles';
 import Spinner from '@mozilla-frontend-infra/components/Spinner';
@@ -76,6 +77,10 @@ const useStyles = makeStyles(theme => ({
 
 export default function Rule({ isNewRule, ...props }) {
   const classes = useStyles();
+  const rulesFilter =
+    props.location.state && props.location.state.rulesFilter
+      ? props.location.state.rulesFilter
+      : [];
   const [rule, setRule] = useState(
     props.location.state && props.location.state.rule
       ? props.location.state.rule
@@ -131,6 +136,26 @@ export default function Rule({ isNewRule, ...props }) {
     setRule(assocPath([name], value, rule));
   };
 
+  const redirectWithRulesFilter = hashFilter => {
+    const queryString = {};
+
+    if (rulesFilter.length > 0) {
+      // eslint-disable-next-line prefer-destructuring
+      queryString.product = rulesFilter[0];
+
+      if (rulesFilter.length > 1 && rulesFilter[1]) {
+        // eslint-disable-next-line prefer-destructuring
+        queryString.channel = rulesFilter[1];
+      }
+    }
+
+    props.history.push(
+      `/rules?${
+        Object.keys(queryString).length > 0 ? stringify(queryString) : ''
+      }#${hashFilter}`
+    );
+  };
+
   const handleDateTimeChange = date => {
     setScheduleDate(date);
     setDateTimePickerError(null);
@@ -147,7 +172,7 @@ export default function Rule({ isNewRule, ...props }) {
     });
 
     if (!error) {
-      props.history.push(`/rules#ruleId=${rule.rule_id}`);
+      redirectWithRulesFilter(`ruleId=${rule.rule_id}`);
     }
   };
 
@@ -185,7 +210,7 @@ export default function Rule({ isNewRule, ...props }) {
     });
 
     if (!error) {
-      props.history.push(`/rules#scId=${response.data.sc_id}`);
+      redirectWithRulesFilter(`scId=${response.data.sc_id}`);
     }
   };
 
@@ -227,7 +252,7 @@ export default function Rule({ isNewRule, ...props }) {
       });
 
       if (!error) {
-        props.history.push(`/rules#scId=${rule.sc_id}`);
+        redirectWithRulesFilter(`scId=${rule.sc_id}`);
       }
     } else {
       const { data: response, error } = await addSC({
@@ -240,9 +265,9 @@ export default function Rule({ isNewRule, ...props }) {
 
       if (!error) {
         if (response.data.sc_id) {
-          props.history.push(`/rules#scId=${response.data.sc_id}`);
+          redirectWithRulesFilter(`scId=${response.data.sc_id}`);
         } else {
-          props.history.push(`/rules#ruleId=${rule.rule_id}`);
+          redirectWithRulesFilter(`ruleId=${rule.rule_id}`);
         }
       }
     }

--- a/src/views/Rules/Rule/index.jsx
+++ b/src/views/Rules/Rule/index.jsx
@@ -137,23 +137,10 @@ export default function Rule({ isNewRule, ...props }) {
   };
 
   const redirectWithRulesFilter = hashFilter => {
-    const queryString = {};
+    const [product, channel] = rulesFilter;
+    const query = stringify({ product, channel }, { addQueryPrefix: true });
 
-    if (rulesFilter.length > 0) {
-      // eslint-disable-next-line prefer-destructuring
-      queryString.product = rulesFilter[0];
-
-      if (rulesFilter.length > 1 && rulesFilter[1]) {
-        // eslint-disable-next-line prefer-destructuring
-        queryString.channel = rulesFilter[1];
-      }
-    }
-
-    props.history.push(
-      `/rules?${
-        Object.keys(queryString).length > 0 ? stringify(queryString) : ''
-      }#${hashFilter}`
-    );
+    props.history.push(`/rules${query}#${hashFilter}`);
   };
 
   const handleDateTimeChange = date => {


### PR DESCRIPTION
I think this matches what we talked about in #99. However, I'm not sure it's the best fix anymore, per below.

While writing this I noticed that we also redirect to the rules page from ReleaseCard's (backlinks to any Rules that happen to be pointing at Releases: https://github.com/mozilla-frontend-infra/balrog-ui/blob/a56e0dd4f9e94d14dc309fe65d4cecc8082a106d/src/components/ReleaseCard/index.jsx#L175)

Those links will not apply any filters at the moment, which is not ideal. It wouldn't be hard to apply a product filter based on the Release's product for those, but that's not usually enough to be useful. Eg: viewing Firefox releases without a channel filter applied isn't helpful. This makes me wonder if a better solution would be to look at the product and channel of whatever rule is mentioned in the hash filter instead. This would mean we can't apply until we finish loading the rules from the backend, which might be slightly jarring or janky, but it would be more accurate. Do you have any thoughts here?