### PR TITLE
Fix: refresh auth0 tokens

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -50,7 +50,6 @@ axios.interceptors.response.use(
 );
 
 const App = () => {
-  const session = localStorage.getItem(USER_SESSION);
   const [authorize, setAuthorize] = useState(
     Boolean(localStorage.getItem(USER_SESSION))
   );
@@ -67,7 +66,9 @@ const App = () => {
   });
   // Wait until authorization is done before rendering
   // to make sure users who are logged in are able to access protected views
-  const [ready, setReady] = useState(Boolean(!session));
+  const [ready, setReady] = useState(
+    Boolean(!localStorage.getItem(USER_SESSION))
+  );
   const handleAuthorize = user => {
     setAuthContext({
       ...authContext,
@@ -81,6 +82,8 @@ const App = () => {
   };
 
   const render = () => {
+    const session = localStorage.getItem(USER_SESSION);
+
     if (session) {
       const user = JSON.parse(session);
       const expires = new Date(user.expiration);


### PR DESCRIPTION
The problem was that it was always reading a previous of localStorage since the `render` callback would run but the function itself won't run.

Fixes https://github.com/mozilla-frontend-infra/balrog-ui/issues/16.