### PR TITLE
Fix channel filter to account for trailing `*` properly

### DIFF
--- a/src/views/Rules/ListRules/index.jsx
+++ b/src/views/Rules/ListRules/index.jsx
@@ -309,10 +309,8 @@ function ListRules(props) {
                 if (ruleChannel !== channelFilter) {
                   return false;
                 }
-              } else {
-                if (!channelFilter.startsWith(ruleChannel.split("*")[0])) {
-                  return false;
-                }
+              } else if (!channelFilter.startsWith(ruleChannel.split('*')[0])) {
+                return false;
               }
             }
 

--- a/src/views/Rules/ListRules/index.jsx
+++ b/src/views/Rules/ListRules/index.jsx
@@ -304,11 +304,16 @@ function ListRules(props) {
               return false;
             }
 
-            if (
-              channelFilter &&
-              ruleChannel.replace('*', '') !== channelFilter
-            ) {
-              return false;
+            if (channelFilter) {
+              if (ruleChannel.indexOf('*') === -1) {
+                if (ruleChannel !== channelFilter) {
+                  return false;
+                }
+              } else {
+                if (!channelFilter.startsWith(ruleChannel.split("*")[0])) {
+                  return false;
+                }
+              }
             }
 
             return true;


### PR DESCRIPTION
It was only working if the characters before the glob matched the filtered channel exactly, instead of checking to see if the filtered channel started with the base characters.