### PR TITLE
Make close icon white in the Snackbar component

### DIFF
--- a/src/components/Snackbar/index.jsx
+++ b/src/components/Snackbar/index.jsx
@@ -19,6 +19,9 @@ const variantIcon = {
   info: InformationIcon,
 };
 const useStyles = makeStyles(theme => ({
+  iconButtonRoot: {
+    color: theme.palette.common.white,
+  },
   success: {
     backgroundColor: green[600],
   },
@@ -54,7 +57,10 @@ function Snackbar(props) {
       <SnackbarContent
         className={classes[variant]}
         action={
-          <IconButton aria-label="Close" onClick={onClose}>
+          <IconButton
+            classes={{ root: classes.iconButtonRoot }}
+            aria-label="Close"
+            onClick={onClose}>
             <CloseIcon />
           </IconButton>
         }


### PR DESCRIPTION
The close icon had a black color which doesn't sit well on dark colors (e.g., green). This makes the default button white.