### PR TITLE
Handle rules without channel or product being set when analyzing whether or not signoff is required

### DIFF
--- a/src/utils/requiredSignoffs.js
+++ b/src/utils/requiredSignoffs.js
@@ -1,9 +1,9 @@
 const ruleMatchesRequiredSignoff = (rule, rs) => {
-  if (rule.product !== rs.product) {
+  if (rule.product && rule.product !== rs.product) {
     return false;
   }
 
-  if (rule.channel !== rs.channel) {
+  if (rule.channel && rule.channel !== rs.channel) {
     if (rule.channel.endsWith('*')) {
       // If a globbing rule's base doesn't match the required signoff channel
       // it doesn't apply


### PR DESCRIPTION
I discovered this in production today, where we have Required Signoffs enabled for some product+channels which have Rules where `channel` is null - it ends up throwing a TypeError when trying to call `endsWith`.

We also need to fix the case where a Rule's `product` may be null, in which case all Required Signoffs will apply to it.