### PR TITLE
Fix logic in isRuleSelected

### DIFF
--- a/src/views/Rules/ListRules/index.jsx
+++ b/src/views/Rules/ListRules/index.jsx
@@ -1006,7 +1006,7 @@ function ListRules(props) {
     if (hashQuery.scId) {
       return Boolean(
         rule.scheduledChange &&
-          Number(rule.scheduledChange.sc_id === hashQuery.scId)
+          Number(rule.scheduledChange.sc_id === Number(hashQuery.scId))
       );
     }
   };


### PR DESCRIPTION
I noticed in the demo we gave yesterday that when we updated a rule, it didn't get selected and scrolled to. This fixes the issue.