### PR TITLE
Hide unused fields for Guardian on Rule Edit page.

### DIFF
--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -35,6 +35,23 @@ export const RULE_DIFF_PROPERTIES = [
   'update_type',
   'version',
 ];
+// Products that use only a subset of the available Rule fields
+// should define them here.
+export const RULE_PRODUCT_PROPERTIES = {
+  Guardian: [
+    'rule_id',
+    'alias',
+    'priority',
+    'mapping',
+    'fallbackMapping',
+    'backgroundRate',
+    'product',
+    'version',
+    'channel',
+    'buildTarget',
+    'comment',
+  ],
+};
 export const CONTENT_MAX_WIDTH = 980;
 export const APP_BAR_HEIGHT = 64;
 export const SNACKBAR_AUTO_HIDE_DURATION = 5000;

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -37,19 +37,19 @@ export const RULE_DIFF_PROPERTIES = [
 ];
 // Products that use only a subset of the available Rule fields
 // should define them here.
-export const RULE_PRODUCT_PROPERTIES = {
+export const RULE_PRODUCT_UNSUPPORTED_PROPERTIES = {
   Guardian: [
-    'rule_id',
-    'alias',
-    'priority',
-    'mapping',
-    'fallbackMapping',
-    'backgroundRate',
-    'product',
-    'version',
-    'channel',
-    'buildTarget',
-    'comment',
+    'buildID',
+    'distVersion',
+    'distribution',
+    'headerArchitecture',
+    'instructionSet',
+    'jaws',
+    'locale',
+    'memory',
+    'mig64',
+    'osVersion',
+    'update_type',
   ],
 };
 export const CONTENT_MAX_WIDTH = 980;

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -49,7 +49,6 @@ export const RULE_PRODUCT_UNSUPPORTED_PROPERTIES = {
     'memory',
     'mig64',
     'osVersion',
-    'update_type',
   ],
 };
 export const CONTENT_MAX_WIDTH = 980;

--- a/src/views/Rules/Rule/index.jsx
+++ b/src/views/Rules/Rule/index.jsx
@@ -36,7 +36,7 @@ import { withUser } from '../../../utils/AuthContext';
 import {
   EMPTY_MENU_ITEM_CHAR,
   SPLIT_WITH_NEWLINES_AND_COMMA_REGEX,
-  RULE_PRODUCT_PROPERTIES,
+  RULE_PRODUCT_UNSUPPORTED_PROPERTIES,
 } from '../../../utils/constants';
 
 const initialRule = {
@@ -364,6 +364,12 @@ function Rule({ isNewRule, user, ...props }) {
     return `Update Rule ${ruleId}${rule.alias ? ` (${rule.alias})` : ''}`;
   };
 
+  const showField = field =>
+    !(
+      rule.product in RULE_PRODUCT_UNSUPPORTED_PROPERTIES &&
+      RULE_PRODUCT_UNSUPPORTED_PROPERTIES[rule.product].includes(field)
+    );
+
   return (
     <Dashboard title={getTitle()}>
       {isLoading && <Spinner loading />}
@@ -404,8 +410,7 @@ function Rule({ isNewRule, user, ...props }) {
                 }}
               />
             </Grid>
-            {(!(rule.product in RULE_PRODUCT_PROPERTIES) ||
-              RULE_PRODUCT_PROPERTIES[rule.product].includes('channel')) && (
+            {showField('channel') && (
               <Grid item xs={12} sm={6}>
                 <AutoCompleteText
                   value={defaultToEmptyString(rule.channel)}
@@ -421,8 +426,7 @@ function Rule({ isNewRule, user, ...props }) {
                 />
               </Grid>
             )}
-            {(!(rule.product in RULE_PRODUCT_PROPERTIES) ||
-              RULE_PRODUCT_PROPERTIES[rule.product].includes('mapping')) && (
+            {showField('mapping') && (
               <Grid item xs={12} sm={6}>
                 <AutoCompleteText
                   value={defaultToEmptyString(rule.mapping)}
@@ -439,10 +443,7 @@ function Rule({ isNewRule, user, ...props }) {
                 />
               </Grid>
             )}
-            {(!(rule.product in RULE_PRODUCT_PROPERTIES) ||
-              RULE_PRODUCT_PROPERTIES[rule.product].includes(
-                'fallbackMapping'
-              )) && (
+            {showField('fallbackMapping') && (
               <Grid item xs={12} sm={6}>
                 <AutoCompleteText
                   value={defaultToEmptyString(rule.fallbackMapping)}
@@ -458,10 +459,7 @@ function Rule({ isNewRule, user, ...props }) {
                 />
               </Grid>
             )}
-            {(!(rule.product in RULE_PRODUCT_PROPERTIES) ||
-              RULE_PRODUCT_PROPERTIES[rule.product].includes(
-                'backgroundRate'
-              )) && (
+            {showField('backgroundRate') && (
               <Grid item xs={12} sm={6}>
                 <NumberFormat
                   allowNegative={false}
@@ -474,8 +472,7 @@ function Rule({ isNewRule, user, ...props }) {
                 />
               </Grid>
             )}
-            {(!(rule.product in RULE_PRODUCT_PROPERTIES) ||
-              RULE_PRODUCT_PROPERTIES[rule.product].includes('priority')) && (
+            {showField('priority') && (
               <Grid item xs={12} sm={6}>
                 <NumberFormat
                   allowNegative={false}
@@ -488,8 +485,7 @@ function Rule({ isNewRule, user, ...props }) {
                 />
               </Grid>
             )}
-            {(!(rule.product in RULE_PRODUCT_PROPERTIES) ||
-              RULE_PRODUCT_PROPERTIES[rule.product].includes('version')) && (
+            {showField('version') && (
               <Grid item xs={12} sm={6}>
                 <TextField
                   fullWidth
@@ -500,8 +496,7 @@ function Rule({ isNewRule, user, ...props }) {
                 />
               </Grid>
             )}
-            {(!(rule.product in RULE_PRODUCT_PROPERTIES) ||
-              RULE_PRODUCT_PROPERTIES[rule.product].includes('buildID')) && (
+            {showField('buildID') && (
               <Grid item xs={12} sm={6}>
                 <TextField
                   fullWidth
@@ -512,8 +507,7 @@ function Rule({ isNewRule, user, ...props }) {
                 />
               </Grid>
             )}
-            {(!(rule.product in RULE_PRODUCT_PROPERTIES) ||
-              RULE_PRODUCT_PROPERTIES[rule.product].includes('locale')) && (
+            {showField('locale') && (
               <Grid item xs={12} md={6}>
                 <TextField
                   helperText="Enter each locale on its own line"
@@ -527,8 +521,7 @@ function Rule({ isNewRule, user, ...props }) {
                 />
               </Grid>
             )}
-            {(!(rule.product in RULE_PRODUCT_PROPERTIES) ||
-              RULE_PRODUCT_PROPERTIES[rule.product].includes('osVersion')) && (
+            {showField('osVersion') && (
               <Grid item xs={12} md={6}>
                 <TextField
                   helperText="Enter each OS version on its own line"
@@ -542,10 +535,7 @@ function Rule({ isNewRule, user, ...props }) {
                 />
               </Grid>
             )}
-            {(!(rule.product in RULE_PRODUCT_PROPERTIES) ||
-              RULE_PRODUCT_PROPERTIES[rule.product].includes(
-                'buildTarget'
-              )) && (
+            {showField('buildTarget') && (
               <Grid item xs={12} sm={6}>
                 <TextField
                   fullWidth
@@ -556,10 +546,7 @@ function Rule({ isNewRule, user, ...props }) {
                 />
               </Grid>
             )}
-            {(!(rule.product in RULE_PRODUCT_PROPERTIES) ||
-              RULE_PRODUCT_PROPERTIES[rule.product].includes(
-                'instructionSet'
-              )) && (
+            {showField('instructionSet') && (
               <Grid item xs={12} sm={6}>
                 <TextField
                   fullWidth
@@ -570,8 +557,7 @@ function Rule({ isNewRule, user, ...props }) {
                 />
               </Grid>
             )}
-            {(!(rule.product in RULE_PRODUCT_PROPERTIES) ||
-              RULE_PRODUCT_PROPERTIES[rule.product].includes('memory')) && (
+            {showField('memory') && (
               <Grid item xs={12} sm={6}>
                 <TextField
                   fullWidth
@@ -582,8 +568,7 @@ function Rule({ isNewRule, user, ...props }) {
                 />
               </Grid>
             )}
-            {(!(rule.product in RULE_PRODUCT_PROPERTIES) ||
-              RULE_PRODUCT_PROPERTIES[rule.product].includes('jaws')) && (
+            {showField('jaws') && (
               <Grid item xs={12} sm={6}>
                 <TextField
                   fullWidth
@@ -600,10 +585,7 @@ function Rule({ isNewRule, user, ...props }) {
                 </TextField>
               </Grid>
             )}
-            {(!(rule.product in RULE_PRODUCT_PROPERTIES) ||
-              RULE_PRODUCT_PROPERTIES[rule.product].includes(
-                'distribution'
-              )) && (
+            {showField('distribution') && (
               <Grid item xs={12} sm={6}>
                 <TextField
                   fullWidth
@@ -614,10 +596,7 @@ function Rule({ isNewRule, user, ...props }) {
                 />
               </Grid>
             )}
-            {(!(rule.product in RULE_PRODUCT_PROPERTIES) ||
-              RULE_PRODUCT_PROPERTIES[rule.product].includes(
-                'distVersion'
-              )) && (
+            {showField('distVersion') && (
               <Grid item xs={12} sm={6}>
                 <TextField
                   fullWidth
@@ -628,10 +607,7 @@ function Rule({ isNewRule, user, ...props }) {
                 />
               </Grid>
             )}
-            {(!(rule.product in RULE_PRODUCT_PROPERTIES) ||
-              RULE_PRODUCT_PROPERTIES[rule.product].includes(
-                'headerArchitecture'
-              )) && (
+            {showField('headerArchitecture') && (
               <Grid item xs={12} sm={6}>
                 <TextField
                   fullWidth
@@ -642,8 +618,7 @@ function Rule({ isNewRule, user, ...props }) {
                 />
               </Grid>
             )}
-            {(!(rule.product in RULE_PRODUCT_PROPERTIES) ||
-              RULE_PRODUCT_PROPERTIES[rule.product].includes('mig64')) && (
+            {showField('mig64') && (
               <Grid item xs={12} sm={6}>
                 <TextField
                   fullWidth
@@ -660,8 +635,7 @@ function Rule({ isNewRule, user, ...props }) {
                 </TextField>
               </Grid>
             )}
-            {(!(rule.product in RULE_PRODUCT_PROPERTIES) ||
-              RULE_PRODUCT_PROPERTIES[rule.product].includes('alias')) && (
+            {showField('alias') && (
               <Grid item xs={12} sm={6}>
                 <TextField
                   fullWidth
@@ -672,10 +646,7 @@ function Rule({ isNewRule, user, ...props }) {
                 />
               </Grid>
             )}
-            {(!(rule.product in RULE_PRODUCT_PROPERTIES) ||
-              RULE_PRODUCT_PROPERTIES[rule.product].includes(
-                'update_type'
-              )) && (
+            {showField('update_type') && (
               <Grid item xs={12} sm={6}>
                 <TextField
                   fullWidth
@@ -690,8 +661,7 @@ function Rule({ isNewRule, user, ...props }) {
                 </TextField>
               </Grid>
             )}
-            {(!(rule.product in RULE_PRODUCT_PROPERTIES) ||
-              RULE_PRODUCT_PROPERTIES[rule.product].includes('comment')) && (
+            {showField('comment') && (
               <Grid item xs={12}>
                 <TextField
                   fullWidth

--- a/src/views/Rules/Rule/index.jsx
+++ b/src/views/Rules/Rule/index.jsx
@@ -188,7 +188,7 @@ function Rule({ isNewRule, user, ...props }) {
       RULE_PRODUCT_UNSUPPORTED_PROPERTIES[rule.product].includes(field)
     );
   const filterProductData = data =>
-    pick(Object.keys(data).filter(field => productSupportsField(field)), data);
+    pick(Object.keys(data).filter(productSupportsField), data);
   const handleCreateRule = async () => {
     const now = new Date();
     const when =

--- a/src/views/Rules/Rule/index.jsx
+++ b/src/views/Rules/Rule/index.jsx
@@ -36,6 +36,7 @@ import { withUser } from '../../../utils/AuthContext';
 import {
   EMPTY_MENU_ITEM_CHAR,
   SPLIT_WITH_NEWLINES_AND_COMMA_REGEX,
+  RULE_PRODUCT_PROPERTIES,
 } from '../../../utils/constants';
 
 const initialRule = {
@@ -403,230 +404,306 @@ function Rule({ isNewRule, user, ...props }) {
                 }}
               />
             </Grid>
-            <Grid item xs={12} sm={6}>
-              <AutoCompleteText
-                value={defaultToEmptyString(rule.channel)}
-                onValueChange={handleChannelChange}
-                getSuggestions={
-                  channels.data && getSuggestions(channels.data.data.channel)
-                }
-                label="Channel"
-                required
-                inputProps={{
-                  fullWidth: true,
-                }}
-              />
-            </Grid>
-            <Grid item xs={12} sm={6}>
-              <AutoCompleteText
-                value={defaultToEmptyString(rule.mapping)}
-                onValueChange={handleMappingChange}
-                getSuggestions={
-                  releaseNames.data &&
-                  getSuggestions(releaseNames.data.data.names)
-                }
-                label="Mapping"
-                required
-                inputProps={{
-                  fullWidth: true,
-                }}
-              />
-            </Grid>
-            <Grid item xs={12} sm={6}>
-              <AutoCompleteText
-                value={defaultToEmptyString(rule.fallbackMapping)}
-                onValueChange={handleFallbackMappingChange}
-                getSuggestions={
-                  releaseNames.data &&
-                  getSuggestions(releaseNames.data.data.names)
-                }
-                label="Fallback Mapping"
-                inputProps={{
-                  fullWidth: true,
-                }}
-              />
-            </Grid>
-            <Grid item xs={12} sm={6}>
-              <NumberFormat
-                allowNegative={false}
-                label="Background Rate"
-                fullWidth
-                value={rule.backgroundRate}
-                customInput={TextField}
-                onValueChange={handleNumberChange('backgroundRate')}
-                decimalScale={0}
-              />
-            </Grid>
-            <Grid item xs={12} sm={6}>
-              <NumberFormat
-                allowNegative={false}
-                label="Priority"
-                fullWidth
-                value={defaultToEmptyString(rule.priority)}
-                customInput={TextField}
-                onValueChange={handleNumberChange('priority')}
-                decimalScale={0}
-              />
-            </Grid>
-            <Grid item xs={12} sm={6}>
-              <TextField
-                fullWidth
-                label="Version"
-                value={defaultToEmptyString(rule.version)}
-                name="version"
-                onChange={handleInputChange}
-              />
-            </Grid>
-            <Grid item xs={12} sm={6}>
-              <TextField
-                fullWidth
-                label="Build ID"
-                value={defaultToEmptyString(rule.buildID)}
-                name="buildID"
-                onChange={handleInputChange}
-              />
-            </Grid>
-            <Grid item xs={12} md={6}>
-              <TextField
-                helperText="Enter each locale on its own line"
-                multiline
-                rows={4}
-                fullWidth
-                label="Locale"
-                value={localeTextValue}
-                name="locale"
-                onChange={handleTextFieldWithNewLinesChange}
-              />
-            </Grid>
-            <Grid item xs={12} md={6}>
-              <TextField
-                helperText="Enter each OS version on its own line"
-                multiline
-                rows={4}
-                fullWidth
-                label="OS Version"
-                value={osVersionTextValue}
-                name="osVersion"
-                onChange={handleTextFieldWithNewLinesChange}
-              />
-            </Grid>
-            <Grid item xs={12} sm={6}>
-              <TextField
-                fullWidth
-                label="Build Target"
-                value={defaultToEmptyString(rule.buildTarget)}
-                name="buildTarget"
-                onChange={handleInputChange}
-              />
-            </Grid>
-            <Grid item xs={12} sm={6}>
-              <TextField
-                fullWidth
-                label="Instruction Set"
-                value={defaultToEmptyString(rule.instructionSet)}
-                name="instructionSet"
-                onChange={handleInputChange}
-              />
-            </Grid>
-            <Grid item xs={12} sm={6}>
-              <TextField
-                fullWidth
-                label="Memory"
-                value={defaultToEmptyString(rule.memory)}
-                name="memory"
-                onChange={handleInputChange}
-              />
-            </Grid>
-            <Grid item xs={12} sm={6}>
-              <TextField
-                fullWidth
-                label="Incompatible JAWS Screen Reader"
-                select
-                value={rule.jaws || EMPTY_MENU_ITEM_CHAR}
-                name="jaws"
-                onChange={handleInputChange}>
-                <MenuItem value={EMPTY_MENU_ITEM_CHAR}>
-                  {EMPTY_MENU_ITEM_CHAR}
-                </MenuItem>
-                <MenuItem value="true">Yes</MenuItem>
-                <MenuItem value="false">No</MenuItem>
-              </TextField>
-            </Grid>
-            <Grid item xs={12} sm={6}>
-              <TextField
-                fullWidth
-                label="Distribution"
-                value={defaultToEmptyString(rule.distribution)}
-                name="distribution"
-                onChange={handleInputChange}
-              />
-            </Grid>
-            <Grid item xs={12} sm={6}>
-              <TextField
-                fullWidth
-                label="Distribution Version"
-                value={defaultToEmptyString(rule.distVersion)}
-                name="distVersion"
-                onChange={handleInputChange}
-              />
-            </Grid>
-            <Grid item xs={12} sm={6}>
-              <TextField
-                fullWidth
-                label="Header Architecture"
-                value={defaultToEmptyString(rule.headerArchitecture)}
-                name="headerArchitecture"
-                onChange={handleInputChange}
-              />
-            </Grid>
-            <Grid item xs={12} sm={6}>
-              <TextField
-                fullWidth
-                label="64-bit Migration Opt-in"
-                select
-                value={rule.mig64 || EMPTY_MENU_ITEM_CHAR}
-                name="mig64"
-                onChange={handleInputChange}>
-                <MenuItem value={EMPTY_MENU_ITEM_CHAR}>
-                  {EMPTY_MENU_ITEM_CHAR}
-                </MenuItem>
-                <MenuItem value="true">Yes</MenuItem>
-                <MenuItem value="false">No</MenuItem>
-              </TextField>
-            </Grid>
-            <Grid item xs={12} sm={6}>
-              <TextField
-                fullWidth
-                label="Alias"
-                value={defaultToEmptyString(rule.alias)}
-                name="alias"
-                onChange={handleInputChange}
-              />
-            </Grid>
-            <Grid item xs={12} sm={6}>
-              <TextField
-                fullWidth
-                select
-                required
-                label="Update Type"
-                value={rule.update_type || 'minor'}
-                name="update_type"
-                onChange={handleInputChange}>
-                <MenuItem value="minor">minor</MenuItem>
-                <MenuItem value="major">major</MenuItem>
-              </TextField>
-            </Grid>
-            <Grid item xs={12}>
-              <TextField
-                fullWidth
-                multiline
-                rows={4}
-                label="Comment"
-                value={defaultToEmptyString(rule.comment)}
-                name="comment"
-                onChange={handleInputChange}
-              />
-            </Grid>
+            {(!(rule.product in RULE_PRODUCT_PROPERTIES) ||
+              RULE_PRODUCT_PROPERTIES[rule.product].includes('channel')) && (
+              <Grid item xs={12} sm={6}>
+                <AutoCompleteText
+                  value={defaultToEmptyString(rule.channel)}
+                  onValueChange={handleChannelChange}
+                  getSuggestions={
+                    channels.data && getSuggestions(channels.data.data.channel)
+                  }
+                  label="Channel"
+                  required
+                  inputProps={{
+                    fullWidth: true,
+                  }}
+                />
+              </Grid>
+            )}
+            {(!(rule.product in RULE_PRODUCT_PROPERTIES) ||
+              RULE_PRODUCT_PROPERTIES[rule.product].includes('mapping')) && (
+              <Grid item xs={12} sm={6}>
+                <AutoCompleteText
+                  value={defaultToEmptyString(rule.mapping)}
+                  onValueChange={handleMappingChange}
+                  getSuggestions={
+                    releaseNames.data &&
+                    getSuggestions(releaseNames.data.data.names)
+                  }
+                  label="Mapping"
+                  required
+                  inputProps={{
+                    fullWidth: true,
+                  }}
+                />
+              </Grid>
+            )}
+            {(!(rule.product in RULE_PRODUCT_PROPERTIES) ||
+              RULE_PRODUCT_PROPERTIES[rule.product].includes(
+                'fallbackMapping'
+              )) && (
+              <Grid item xs={12} sm={6}>
+                <AutoCompleteText
+                  value={defaultToEmptyString(rule.fallbackMapping)}
+                  onValueChange={handleFallbackMappingChange}
+                  getSuggestions={
+                    releaseNames.data &&
+                    getSuggestions(releaseNames.data.data.names)
+                  }
+                  label="Fallback Mapping"
+                  inputProps={{
+                    fullWidth: true,
+                  }}
+                />
+              </Grid>
+            )}
+            {(!(rule.product in RULE_PRODUCT_PROPERTIES) ||
+              RULE_PRODUCT_PROPERTIES[rule.product].includes(
+                'backgroundRate'
+              )) && (
+              <Grid item xs={12} sm={6}>
+                <NumberFormat
+                  allowNegative={false}
+                  label="Background Rate"
+                  fullWidth
+                  value={rule.backgroundRate}
+                  customInput={TextField}
+                  onValueChange={handleNumberChange('backgroundRate')}
+                  decimalScale={0}
+                />
+              </Grid>
+            )}
+            {(!(rule.product in RULE_PRODUCT_PROPERTIES) ||
+              RULE_PRODUCT_PROPERTIES[rule.product].includes('priority')) && (
+              <Grid item xs={12} sm={6}>
+                <NumberFormat
+                  allowNegative={false}
+                  label="Priority"
+                  fullWidth
+                  value={defaultToEmptyString(rule.priority)}
+                  customInput={TextField}
+                  onValueChange={handleNumberChange('priority')}
+                  decimalScale={0}
+                />
+              </Grid>
+            )}
+            {(!(rule.product in RULE_PRODUCT_PROPERTIES) ||
+              RULE_PRODUCT_PROPERTIES[rule.product].includes('version')) && (
+              <Grid item xs={12} sm={6}>
+                <TextField
+                  fullWidth
+                  label="Version"
+                  value={defaultToEmptyString(rule.version)}
+                  name="version"
+                  onChange={handleInputChange}
+                />
+              </Grid>
+            )}
+            {(!(rule.product in RULE_PRODUCT_PROPERTIES) ||
+              RULE_PRODUCT_PROPERTIES[rule.product].includes('buildID')) && (
+              <Grid item xs={12} sm={6}>
+                <TextField
+                  fullWidth
+                  label="Build ID"
+                  value={defaultToEmptyString(rule.buildID)}
+                  name="buildID"
+                  onChange={handleInputChange}
+                />
+              </Grid>
+            )}
+            {(!(rule.product in RULE_PRODUCT_PROPERTIES) ||
+              RULE_PRODUCT_PROPERTIES[rule.product].includes('locale')) && (
+              <Grid item xs={12} md={6}>
+                <TextField
+                  helperText="Enter each locale on its own line"
+                  multiline
+                  rows={4}
+                  fullWidth
+                  label="Locale"
+                  value={localeTextValue}
+                  name="locale"
+                  onChange={handleTextFieldWithNewLinesChange}
+                />
+              </Grid>
+            )}
+            {(!(rule.product in RULE_PRODUCT_PROPERTIES) ||
+              RULE_PRODUCT_PROPERTIES[rule.product].includes('osVersion')) && (
+              <Grid item xs={12} md={6}>
+                <TextField
+                  helperText="Enter each OS version on its own line"
+                  multiline
+                  rows={4}
+                  fullWidth
+                  label="OS Version"
+                  value={osVersionTextValue}
+                  name="osVersion"
+                  onChange={handleTextFieldWithNewLinesChange}
+                />
+              </Grid>
+            )}
+            {(!(rule.product in RULE_PRODUCT_PROPERTIES) ||
+              RULE_PRODUCT_PROPERTIES[rule.product].includes(
+                'buildTarget'
+              )) && (
+              <Grid item xs={12} sm={6}>
+                <TextField
+                  fullWidth
+                  label="Build Target"
+                  value={defaultToEmptyString(rule.buildTarget)}
+                  name="buildTarget"
+                  onChange={handleInputChange}
+                />
+              </Grid>
+            )}
+            {(!(rule.product in RULE_PRODUCT_PROPERTIES) ||
+              RULE_PRODUCT_PROPERTIES[rule.product].includes(
+                'instructionSet'
+              )) && (
+              <Grid item xs={12} sm={6}>
+                <TextField
+                  fullWidth
+                  label="Instruction Set"
+                  value={defaultToEmptyString(rule.instructionSet)}
+                  name="instructionSet"
+                  onChange={handleInputChange}
+                />
+              </Grid>
+            )}
+            {(!(rule.product in RULE_PRODUCT_PROPERTIES) ||
+              RULE_PRODUCT_PROPERTIES[rule.product].includes('memory')) && (
+              <Grid item xs={12} sm={6}>
+                <TextField
+                  fullWidth
+                  label="Memory"
+                  value={defaultToEmptyString(rule.memory)}
+                  name="memory"
+                  onChange={handleInputChange}
+                />
+              </Grid>
+            )}
+            {(!(rule.product in RULE_PRODUCT_PROPERTIES) ||
+              RULE_PRODUCT_PROPERTIES[rule.product].includes('jaws')) && (
+              <Grid item xs={12} sm={6}>
+                <TextField
+                  fullWidth
+                  label="Incompatible JAWS Screen Reader"
+                  select
+                  value={rule.jaws || EMPTY_MENU_ITEM_CHAR}
+                  name="jaws"
+                  onChange={handleInputChange}>
+                  <MenuItem value={EMPTY_MENU_ITEM_CHAR}>
+                    {EMPTY_MENU_ITEM_CHAR}
+                  </MenuItem>
+                  <MenuItem value="true">Yes</MenuItem>
+                  <MenuItem value="false">No</MenuItem>
+                </TextField>
+              </Grid>
+            )}
+            {(!(rule.product in RULE_PRODUCT_PROPERTIES) ||
+              RULE_PRODUCT_PROPERTIES[rule.product].includes(
+                'distribution'
+              )) && (
+              <Grid item xs={12} sm={6}>
+                <TextField
+                  fullWidth
+                  label="Distribution"
+                  value={defaultToEmptyString(rule.distribution)}
+                  name="distribution"
+                  onChange={handleInputChange}
+                />
+              </Grid>
+            )}
+            {(!(rule.product in RULE_PRODUCT_PROPERTIES) ||
+              RULE_PRODUCT_PROPERTIES[rule.product].includes(
+                'distVersion'
+              )) && (
+              <Grid item xs={12} sm={6}>
+                <TextField
+                  fullWidth
+                  label="Distribution Version"
+                  value={defaultToEmptyString(rule.distVersion)}
+                  name="distVersion"
+                  onChange={handleInputChange}
+                />
+              </Grid>
+            )}
+            {(!(rule.product in RULE_PRODUCT_PROPERTIES) ||
+              RULE_PRODUCT_PROPERTIES[rule.product].includes(
+                'headerArchitecture'
+              )) && (
+              <Grid item xs={12} sm={6}>
+                <TextField
+                  fullWidth
+                  label="Header Architecture"
+                  value={defaultToEmptyString(rule.headerArchitecture)}
+                  name="headerArchitecture"
+                  onChange={handleInputChange}
+                />
+              </Grid>
+            )}
+            {(!(rule.product in RULE_PRODUCT_PROPERTIES) ||
+              RULE_PRODUCT_PROPERTIES[rule.product].includes('mig64')) && (
+              <Grid item xs={12} sm={6}>
+                <TextField
+                  fullWidth
+                  label="64-bit Migration Opt-in"
+                  select
+                  value={rule.mig64 || EMPTY_MENU_ITEM_CHAR}
+                  name="mig64"
+                  onChange={handleInputChange}>
+                  <MenuItem value={EMPTY_MENU_ITEM_CHAR}>
+                    {EMPTY_MENU_ITEM_CHAR}
+                  </MenuItem>
+                  <MenuItem value="true">Yes</MenuItem>
+                  <MenuItem value="false">No</MenuItem>
+                </TextField>
+              </Grid>
+            )}
+            {(!(rule.product in RULE_PRODUCT_PROPERTIES) ||
+              RULE_PRODUCT_PROPERTIES[rule.product].includes('alias')) && (
+              <Grid item xs={12} sm={6}>
+                <TextField
+                  fullWidth
+                  label="Alias"
+                  value={defaultToEmptyString(rule.alias)}
+                  name="alias"
+                  onChange={handleInputChange}
+                />
+              </Grid>
+            )}
+            {(!(rule.product in RULE_PRODUCT_PROPERTIES) ||
+              RULE_PRODUCT_PROPERTIES[rule.product].includes(
+                'update_type'
+              )) && (
+              <Grid item xs={12} sm={6}>
+                <TextField
+                  fullWidth
+                  select
+                  required
+                  label="Update Type"
+                  value={rule.update_type || 'minor'}
+                  name="update_type"
+                  onChange={handleInputChange}>
+                  <MenuItem value="minor">minor</MenuItem>
+                  <MenuItem value="major">major</MenuItem>
+                </TextField>
+              </Grid>
+            )}
+            {(!(rule.product in RULE_PRODUCT_PROPERTIES) ||
+              RULE_PRODUCT_PROPERTIES[rule.product].includes('comment')) && (
+              <Grid item xs={12}>
+                <TextField
+                  fullWidth
+                  multiline
+                  rows={4}
+                  label="Comment"
+                  value={defaultToEmptyString(rule.comment)}
+                  name="comment"
+                  onChange={handleInputChange}
+                />
+              </Grid>
+            )}
           </Grid>
         </Fragment>
       )}

--- a/src/views/Rules/Rule/index.jsx
+++ b/src/views/Rules/Rule/index.jsx
@@ -1,7 +1,7 @@
 import React, { Fragment, useState, useEffect } from 'react';
 import classNames from 'classnames';
 import { bool } from 'prop-types';
-import { defaultTo, assocPath } from 'ramda';
+import { defaultTo, assocPath, pick } from 'ramda';
 import { stringify } from 'qs';
 import NumberFormat from 'react-number-format';
 import { makeStyles } from '@material-ui/styles';
@@ -182,6 +182,13 @@ function Rule({ isNewRule, user, ...props }) {
     }
   };
 
+  const productSupportsField = field =>
+    !(
+      rule.product in RULE_PRODUCT_UNSUPPORTED_PROPERTIES &&
+      RULE_PRODUCT_UNSUPPORTED_PROPERTIES[rule.product].includes(field)
+    );
+  const filterProductData = data =>
+    pick(Object.keys(data).filter(field => productSupportsField(field)), data);
   const handleCreateRule = async () => {
     const now = new Date();
     const when =
@@ -212,7 +219,7 @@ function Rule({ isNewRule, user, ...props }) {
     const { data: response, error } = await addSC({
       change_type: 'insert',
       when,
-      ...data,
+      ...filterProductData(data),
     });
 
     if (!error) {
@@ -254,7 +261,7 @@ function Rule({ isNewRule, user, ...props }) {
         sc_data_version: rule.sc_data_version,
         data_version: rule.data_version,
         when,
-        ...data,
+        ...filterProductData(data),
       });
 
       if (!error) {
@@ -266,7 +273,7 @@ function Rule({ isNewRule, user, ...props }) {
         data_version: rule.data_version,
         change_type: 'update',
         when,
-        ...data,
+        ...filterProductData(data),
       });
 
       if (!error) {
@@ -364,12 +371,6 @@ function Rule({ isNewRule, user, ...props }) {
     return `Update Rule ${ruleId}${rule.alias ? ` (${rule.alias})` : ''}`;
   };
 
-  const showField = field =>
-    !(
-      rule.product in RULE_PRODUCT_UNSUPPORTED_PROPERTIES &&
-      RULE_PRODUCT_UNSUPPORTED_PROPERTIES[rule.product].includes(field)
-    );
-
   return (
     <Dashboard title={getTitle()}>
       {isLoading && <Spinner loading />}
@@ -410,7 +411,7 @@ function Rule({ isNewRule, user, ...props }) {
                 }}
               />
             </Grid>
-            {showField('channel') && (
+            {productSupportsField('channel') && (
               <Grid item xs={12} sm={6}>
                 <AutoCompleteText
                   value={defaultToEmptyString(rule.channel)}
@@ -426,7 +427,7 @@ function Rule({ isNewRule, user, ...props }) {
                 />
               </Grid>
             )}
-            {showField('mapping') && (
+            {productSupportsField('mapping') && (
               <Grid item xs={12} sm={6}>
                 <AutoCompleteText
                   value={defaultToEmptyString(rule.mapping)}
@@ -443,7 +444,7 @@ function Rule({ isNewRule, user, ...props }) {
                 />
               </Grid>
             )}
-            {showField('fallbackMapping') && (
+            {productSupportsField('fallbackMapping') && (
               <Grid item xs={12} sm={6}>
                 <AutoCompleteText
                   value={defaultToEmptyString(rule.fallbackMapping)}
@@ -459,7 +460,7 @@ function Rule({ isNewRule, user, ...props }) {
                 />
               </Grid>
             )}
-            {showField('backgroundRate') && (
+            {productSupportsField('backgroundRate') && (
               <Grid item xs={12} sm={6}>
                 <NumberFormat
                   allowNegative={false}
@@ -472,7 +473,7 @@ function Rule({ isNewRule, user, ...props }) {
                 />
               </Grid>
             )}
-            {showField('priority') && (
+            {productSupportsField('priority') && (
               <Grid item xs={12} sm={6}>
                 <NumberFormat
                   allowNegative={false}
@@ -485,7 +486,7 @@ function Rule({ isNewRule, user, ...props }) {
                 />
               </Grid>
             )}
-            {showField('version') && (
+            {productSupportsField('version') && (
               <Grid item xs={12} sm={6}>
                 <TextField
                   fullWidth
@@ -496,7 +497,7 @@ function Rule({ isNewRule, user, ...props }) {
                 />
               </Grid>
             )}
-            {showField('buildID') && (
+            {productSupportsField('buildID') && (
               <Grid item xs={12} sm={6}>
                 <TextField
                   fullWidth
@@ -507,7 +508,7 @@ function Rule({ isNewRule, user, ...props }) {
                 />
               </Grid>
             )}
-            {showField('locale') && (
+            {productSupportsField('locale') && (
               <Grid item xs={12} md={6}>
                 <TextField
                   helperText="Enter each locale on its own line"
@@ -521,7 +522,7 @@ function Rule({ isNewRule, user, ...props }) {
                 />
               </Grid>
             )}
-            {showField('osVersion') && (
+            {productSupportsField('osVersion') && (
               <Grid item xs={12} md={6}>
                 <TextField
                   helperText="Enter each OS version on its own line"
@@ -535,7 +536,7 @@ function Rule({ isNewRule, user, ...props }) {
                 />
               </Grid>
             )}
-            {showField('buildTarget') && (
+            {productSupportsField('buildTarget') && (
               <Grid item xs={12} sm={6}>
                 <TextField
                   fullWidth
@@ -546,7 +547,7 @@ function Rule({ isNewRule, user, ...props }) {
                 />
               </Grid>
             )}
-            {showField('instructionSet') && (
+            {productSupportsField('instructionSet') && (
               <Grid item xs={12} sm={6}>
                 <TextField
                   fullWidth
@@ -557,7 +558,7 @@ function Rule({ isNewRule, user, ...props }) {
                 />
               </Grid>
             )}
-            {showField('memory') && (
+            {productSupportsField('memory') && (
               <Grid item xs={12} sm={6}>
                 <TextField
                   fullWidth
@@ -568,7 +569,7 @@ function Rule({ isNewRule, user, ...props }) {
                 />
               </Grid>
             )}
-            {showField('jaws') && (
+            {productSupportsField('jaws') && (
               <Grid item xs={12} sm={6}>
                 <TextField
                   fullWidth
@@ -585,7 +586,7 @@ function Rule({ isNewRule, user, ...props }) {
                 </TextField>
               </Grid>
             )}
-            {showField('distribution') && (
+            {productSupportsField('distribution') && (
               <Grid item xs={12} sm={6}>
                 <TextField
                   fullWidth
@@ -596,7 +597,7 @@ function Rule({ isNewRule, user, ...props }) {
                 />
               </Grid>
             )}
-            {showField('distVersion') && (
+            {productSupportsField('distVersion') && (
               <Grid item xs={12} sm={6}>
                 <TextField
                   fullWidth
@@ -607,7 +608,7 @@ function Rule({ isNewRule, user, ...props }) {
                 />
               </Grid>
             )}
-            {showField('headerArchitecture') && (
+            {productSupportsField('headerArchitecture') && (
               <Grid item xs={12} sm={6}>
                 <TextField
                   fullWidth
@@ -618,7 +619,7 @@ function Rule({ isNewRule, user, ...props }) {
                 />
               </Grid>
             )}
-            {showField('mig64') && (
+            {productSupportsField('mig64') && (
               <Grid item xs={12} sm={6}>
                 <TextField
                   fullWidth
@@ -635,7 +636,7 @@ function Rule({ isNewRule, user, ...props }) {
                 </TextField>
               </Grid>
             )}
-            {showField('alias') && (
+            {productSupportsField('alias') && (
               <Grid item xs={12} sm={6}>
                 <TextField
                   fullWidth
@@ -646,7 +647,7 @@ function Rule({ isNewRule, user, ...props }) {
                 />
               </Grid>
             )}
-            {showField('update_type') && (
+            {productSupportsField('update_type') && (
               <Grid item xs={12} sm={6}>
                 <TextField
                   fullWidth
@@ -661,7 +662,7 @@ function Rule({ isNewRule, user, ...props }) {
                 </TextField>
               </Grid>
             )}
-            {showField('comment') && (
+            {productSupportsField('comment') && (
               <Grid item xs={12}>
                 <TextField
                   fullWidth


### PR DESCRIPTION
We're in the process of adding support for the new Guardian product to Balrog. One of the things that will be different about its updates, is that the update URL will not contain most of the fields that Firefox updates do. In order to avoid confusion, I'd like to hide these fields to avoid any confusion.

At this time, the backend is not going to be smart enough to refuse to accept Rules for Guardian that contain these fields, so I'm specifically _not_ hiding them on the Rules view. On the off chance they get set by accident, it would be confusing to have values but not show them.