### PR TITLE
Replaced with default port.

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,4 +7,4 @@ To get started:
 1. Run `yarn` to install all dependencies
 2. `yarn start` to start the development server
 
-Once the server is running, navigate to http://localhost:5000 to see the UI.
+Once the server is running, navigate to http://localhost:9000 to see the UI.


### PR DESCRIPTION
Project default pot defined as defined in` neutrinorc.js`
`const DEFAULT_PORT = 9000;`